### PR TITLE
Retaliate mobs no longer break windows.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -47,3 +47,9 @@
 /mob/living/simple_animal/hostile/retaliate/adjustBruteLoss(var/damage)
 	..(damage)
 	Retaliate()
+
+/mob/living/simple_animal/hostile/retaliate/DestroySurroundings()
+	for(var/dir in cardinal) // North, South, East, West
+		var/obj/structure/obstacle = locate(/obj/structure, get_step(src, dir))
+		if(istype(istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table))
+			obstacle.attack_animal(src)


### PR DESCRIPTION
Reason for the change:

I observed the round and the new "undead" event procced. 

As expected a LOT of mobs spawned, most of them spawned in the maintenance tunnels. The mobs then proceeded to break the windows in maintenance and around the station. De pressurizing it in the matter of minutes.

I believe that this event is way to severe, especially considering that those mobs are rather robust.
