### PR TITLE
Undead event balancing

### DIFF
--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -103,7 +103,7 @@ var/global/list/possibleEvents = list()
 			possibleEvents[/datum/event/alien_infestation] = max(active_with_role["Security"], 5) + 2.5
 		if(!sent_ninja_to_station && toggle_space_ninja)
 			possibleEvents[/datum/event/space_ninja] = max(active_with_role["Security"], 5)
-	possibleEvents[/datum/event/undead] = active_with_role["Security"] * 25
+	possibleEvents[/datum/event/undead] = active_with_role["Security"] * 10
 	possibleEvents[/datum/event/ghosts] = active_with_role["Security"] * 25
 
 

--- a/code/modules/events/sayuevents/undead.dm
+++ b/code/modules/events/sayuevents/undead.dm
@@ -1,5 +1,5 @@
 /datum/event/undead
-	var/spawn_prob = 15
+	var/spawn_prob = 10
 	startWhen = 2
 	announceWhen = 3
 	oneShot			= 1
@@ -10,6 +10,7 @@
 		RS.kill()
 	start()
 		for(var/area/A)
+			if(A.z != 1) continue //Spook on main station only.
 			if(A.luminosity) continue
 //			if(A.lighting_space) continue
 			if(A.type == /area) continue


### PR DESCRIPTION
Made undead spawn on the main station only.
Reduced the amount of undead from about 600 to about 400.
Reduced the chance for the undead event by about half.
