### PR TITLE
Fixes a critical exploit with the autolathe.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -275,9 +275,42 @@ var/global/list/autolathe_recipes_hidden = list( \
 	if (!busy)
 		if(href_list["make"])
 			var/turf/T = get_step(src.loc, get_dir(src,usr))
-			var/obj/template = locate(href_list["make"])
+				
+			// critical exploit fix start -walter0o
+			var/obj/item/template = null
+			var/attempting_to_build = locate(href_list["make"])
+
+			if(!attempting_to_build)
+				return
+
+			if(locate(attempting_to_build, src.L) || locate(attempting_to_build, src.LL)) // see if the requested object is in one of the construction lists, if so, it is legit -walter0o
+				template = attempting_to_build
+
+			else // somebody is trying to exploit, alert admins -walter0o
+				
+				var/turf/LOC = get_turf(usr)
+				message_admins("[key_name_admin(usr)] tried to exploit an autolathe to duplicate <a href='?_src_=vars;Vars=\ref[attempting_to_build]'>[attempting_to_build]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
+				log_admin("EXPLOIT : [key_name(usr)] tried to exploit an autolathe to duplicate [attempting_to_build] !")		
+				return
+
+			// now check for legit multiplier, also only stacks should pass with one to prevent raw-materials-manipulation -walter0o
+
 			var/multiplier = text2num(href_list["multiplier"])
+			
 			if (!multiplier) multiplier = 1
+			var/max_multiplier = 1
+			
+			if(istype(template, /obj/item/stack)) // stacks are the only items which can have a multiplier higher than 1 -walter0o
+				var/obj/item/stack/S = template
+				max_multiplier = min(S.max_amount, S.m_amt?round(m_amount/S.m_amt):INFINITY, S.g_amt?round(g_amount/S.g_amt):INFINITY)  // pasta from regular_win() to make sure the numbers match -walter0o
+
+			if( (multiplier > max_multiplier) || (multiplier <= 0) ) // somebody is trying to exploit, alert admins-walter0o
+					
+				var/turf/LOC = get_turf(usr)
+				message_admins("[key_name_admin(usr)] tried to exploit an autolathe with multiplier set to <u>[multiplier]</u> on <u>[template]</u>  ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])" , 0)
+				log_admin("EXPLOIT : [key_name(usr)] tried to exploit an autolathe with multiplier set to [multiplier] on [template]  !")
+				return
+
 			var/power = max(2000, (template.m_amt+template.g_amt+template.f_amt)*multiplier/5)
 			if(src.m_amount >= template.m_amt*multiplier && src.g_amount >= template.g_amt*multiplier && src.f_amount >= template.f_amt*multiplier)
 				busy = 1


### PR DESCRIPTION
While browsing through my server's code looking for possible exploits to fix, i noticed the following :

The autolathe can be used to duplicate any and all objs.

The faulty code accepts any refID from the usr without a safetycheck to see if the requested obj is in the autolathe_recipes list.

This works "only" on objs because it will trigger a runtime error if the object has no material vars.

The default buildcost values for obj are zero, so it always goes through the materials-check, but it would not be sufficient to plug this exploit at this point.

The trivial fix is to have a check to see if the given refID is in the autolathe_recipes list, although a datum-based construction method would probably be more robust.

As basically identical autolathe code appears to be used in Baycode , /tg/, /vg/, Para, and all other builds i could look at, i assumed this exploit has been undetected since Goon.

And indeed, the faulty code is present in Gooncode rev4407 and has been ever since.
