### PR TITLE
fixed crafting_master hook

### DIFF
--- a/code/datums/crafting.dm
+++ b/code/datums/crafting.dm
@@ -115,6 +115,10 @@ var/global/datum/crafting_controller/crafting_master
 	var/list/all_crafting_points = list()
 	var/list/all_crafting_recipes = list()
 
+/hook/startup/proc/setupCraftingMaster()
+	crafting_master = new /datum/crafting_controller()
+	return 1
+
 /datum/crafting_controller/New()
 	crafting_master = src
 	add_family("table")


### PR DESCRIPTION
when world.dm got changed from calling the setup procs itself to using hooks,
crafting was overlooked.

why are all commits not tested beforehand in a dev branch ?
