### PR TITLE
Space Law book link fix

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -676,7 +676,7 @@
 		</head>
 
 		<body>
-		<iframe width='100%' height='97%' src="http://80.244.78.90/wiki/index.php/Space_Law&printable=yes" frameborder="0" id="main_frame"></iframe>		</body>
+		<iframe width='100%' height='97%' src="http://80.244.78.90/wiki/index.php?title=Space_law&printable=yes" frameborder="0" id="main_frame"></iframe>		</body>
 
 		</html>
 


### PR DESCRIPTION
Fixed the link in the Space Law book to correctly link to the printable
version of the space law page on the wiki.  Note that it uses Space_law
and not Space_Law on the wiki, as the font is smaller, but there are
some formatting errors on that page.  I can't edit the wiki page
directly to fix this because it's protected, but I wanted to keep the
smaller font to make it easier to read in game.

My first patch of many hopefully, and thanks to UC_guy for helping me get to grips with github.
