### PR TITLE
Vox clone scanner and NO_SCAN fix

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -341,7 +341,7 @@
 	return
 
 /obj/machinery/computer/cloning/proc/scan_mob(mob/living/carbon/human/subject as mob)
-	if ((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna) || (subject.flags & NO_SCAN)))
+	if ((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna) || (subject.flags & NO_SCAN))
 		scantemp = "Error: Unable to locate valid genetic data."
 		return
 	if (subject.brain_op_stage == 4.0)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -341,7 +341,7 @@
 	return
 
 /obj/machinery/computer/cloning/proc/scan_mob(mob/living/carbon/human/subject as mob)
-	if ((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna))
+	if ((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna) || (subject.flags & NO_SCAN)))
 		scantemp = "Error: Unable to locate valid genetic data."
 		return
 	if (subject.brain_op_stage == 4.0)


### PR DESCRIPTION
Stops Vox and any race with NO_SCAN from being scanned into the computer for cloning.
