### PR TITLE
Added potassium to potatoes and phoshorus to Pumpkins

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -174,6 +174,8 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		reagents.add_reagent("potassium", 1+round((potency / 10), 1))
+
 		spawn(5)	//So potency can be set in the proc that creates these crops
 			bitesize = reagents.total_volume
 
@@ -529,6 +531,7 @@
 		spawn(5)	//So potency can be set in the proc that creates these crops
 			reagents.add_reagent("nutriment", 1+round((potency / 6), 1))
 			bitesize = 1+round(reagents.total_volume / 2, 1)
+			reagents.add_reagent("phosphorus", 1+round((potency / 10), 1))
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin/attackby(obj/item/weapon/W as obj, mob/user as mob)


### PR DESCRIPTION
I have added some potassium to potatoes and phosphorus to Pumpkins to
give traitorous hydroponics some escape options (they can mix smoke with
this + sugar). I have chosen those plants for realistic reasons:
Pumpkins got a lot of phosphorus and potatoes a lot of potassium.
