### PR TITLE
Replaced Monkeyized() with working method

### DIFF
--- a/code/modules/genetics/side_effects.dm
+++ b/code/modules/genetics/side_effects.dm
@@ -58,9 +58,7 @@
 
 	finish(mob/living/carbon/human/H)
 		if(!H.reagents.has_reagent("anti_toxin"))
-			// H.monkeyize()					This proc causes the player to be ghosted if their DNA is changed back. Needs fixing. Below is hotfix
-			H.dna.SetSEState(MONKEYBLOCK,1)
-			domutcheck(H, null, )
+			H.monkeyize()
 
 /datum/genetics/side_effect/confuse
 	name = "Confuse"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,4 +1,10 @@
 /mob/living/carbon/human/proc/monkeyize()
+	var/mob/H = src
+	H.dna.SetSEState(MONKEYBLOCK,1)
+	domutcheck(H, null)
+
+/*
+/mob/living/carbon/human/proc/monkeyize()
 	if (monkeyizing)
 		return
 	for(var/obj/item/W in src)
@@ -49,6 +55,7 @@
 	del(animation)
 
 	return O
+*/
 
 /mob/new_player/AIize()
 	spawning = 1


### PR DESCRIPTION
commented out old monkeyized() that was causing the ghosting problems
and put a new one in that sends it through the safe method of
monkeyizing. Tested with all currently used monkeyize() calls so won't
break stuff
