### PR TITLE
Kida Alcohol Lore Fix

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3290,6 +3290,8 @@ datum
 
 				if(alien && alien == IS_SKRELL) //Skrell get very drunk very quickly.
 					d*=5
+				else if(alien && alien == IS_KIDAN) //Alcohol is like water to Kida according to lore
+					d*=0
 
 				M.dizziness += dizzy_adj.
 				if(d >= slur_start && d < pass_out)


### PR DESCRIPTION
According to lore, Kida do not get drunk, at lines 3293-3294 I added an else if statement based on the one for Skrell above it. The variables used are still a mystery to me, so corrections may be needed.
http://80.244.78.90/wiki/index.php/Kidan

"Alcohol is a little bit like drinking water; their bodies can break it down very easily and it doesn't intoxicate."
