### PR TITLE
Reverts hyperzine to its previous state, keep its addictivness.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -403,8 +403,8 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.adjustToxLoss(14)
-				M.adjustOxyLoss(14)
+				M.adjustToxLoss(4)
+				M.adjustOxyLoss(4)
 				M.sleeping += 1
 				..()
 				return
@@ -1916,44 +1916,19 @@ datum
 				..()
 				return
 
-		benazine
-			name = "Benazine"
-			id = "benazine"
-			description = "An innocuous cold medicine, good against Coldingtons. It is also the precursor of the highly addictive stiumlant hyperzine."
-			reagent_state = LIQUID
-			color = "#CCFF00" // rgb: 204, 255, 0
-
-			on_mob_life(var/mob/living/M as mob)
-				..()
-				return
-
 		hyperzine
 			name = "Hyperzine"
 			id = "hyperzine"
-			description = "Hyperzine is a highly effective, long lasting, muscle stimulant. It is highly addictive."
-			reagent_state = SOLID
-			color = "#FFFFFF" // rgb: 255,255,255
+			description = "Hyperzine is a highly effective, long lasting, muscle stimulant."
+			reagent_state = LIQUID
+			color = "#CCFF00" // rgb: 204, 255, 0
+			custom_metabolism = 0.05
 			addictiveness = 80
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				if(!data) data = 1
 				if(prob(5)) M.emote(pick("twitch","blink_r","shiver"))
-				data++
-				switch(data)
-					if(35 to 50)
-						M.adjustOxyLoss(1) //They basically run out of breath
-
-					if(51 to 79) // Their cells burn more oxygen than the body can distribute
-						M.adjustToxLoss(1)
-						M.adjustOxyLoss(1)
-
-					if(80 to INFINITY) // At this point you're fucked
-						M.adjustOxyLoss(2) //you'll pass out pretty fucking quick, and die shortly after
-
 				..()
-
-
 				return
 
 		cryoxadone

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -29,27 +29,17 @@ datum
 			required_reagents = list("water" = 1, "potassium" = 1)
 			result_amount = 2
 			on_reaction(var/datum/reagents/holder, var/created_volume)
-
-				if(holder.has_reagent("benazine"))
-					if(istype(holder.my_atom.loc, /obj/machinery/bunsen_burner))
-						if(holder.my_atom.loc:heated)
-							var/bvolume = holder.get_reagent_amount("benazine")
-							if(bvolume > created_volume / 2)
-								bvolume = created_volume
-							holder.add_reagent("hyperzine", bvolume)
-							holder.isolate_reagent("hyperzine")
-				else
-					var/datum/effect/effect/system/reagents_explosion/e = new()
-					e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
-					e.holder_damage(holder.my_atom)
-					if(isliving(holder.my_atom))
+				var/datum/effect/effect/system/reagents_explosion/e = new()
+				e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
+				e.holder_damage(holder.my_atom)
+				if(isliving(holder.my_atom))
+					e.amount *= 0.5
+					var/mob/living/L = holder.my_atom
+					if(L.stat!=DEAD)
 						e.amount *= 0.5
-						var/mob/living/L = holder.my_atom
-						if(L.stat!=DEAD)
-							e.amount *= 0.5
-					e.start()
-					holder.clear_reagents()
-					return
+				e.start()
+				holder.clear_reagents()
+				return
 
 		emp_pulse
 			name = "EMP Pulse"
@@ -279,24 +269,12 @@ datum
 			required_reagents = list("inaprovaline" = 1, "carbon" = 1)
 			result_amount = 2
 
-		benazine
-			name = "Benazine"
-			id = "benarzine"
-			result = "benazine"
-			required_reagents = list("sugar" = 1, "phosphorus" = 1, "sulfur" = 1,)
-			result_amount = 3
-
-/*
-		Made with benazine and potassium/water combo sekrit recipe.
-
 		hyperzine
 			name = "Hyperzine"
 			id = "hyperzine"
 			result = "hyperzine"
-			required_reagents = list("benazine" = 1, "potassium" = 1, "water" = 1,)
+			required_reagents = list("sugar" = 1, "phosphorus" = 1, "sulfur" = 1,)
 			result_amount = 3
-			requires_heating = 1
-*/
 
 		ryetalyn
 			name = "Ryetalyn"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -729,7 +729,6 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 	name = "Coldingtons Effect"
 	stage = 1
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.reagents.has_reagent("benazine")) return
 		if (prob(30))
 			mob << "<span class='warning'>You feel like you are about to sneeze!</span>"
 		sleep(5)


### PR DESCRIPTION
Revert "Made hyperzine same color as salt, because HAHA"

This reverts commit b23b5b62d98ab5b70a7cc6a198c6fce6ba43e1b7.

Conflicts:
    code/modules/reagents/Chemistry-Reagents.dm

Revert "Made hyperzine harder to make properly."

This reverts commit 489cdf00962f444f1e87f72171b16a6021353c7a.

Removes Benazine

Revert "Nerfs for OD"

This reverts commit 4b94406efb60c523099ffe8606de8917459b78b9.

Revert "Hyperzine fix"

This reverts commit d6702496f92e6915639bc9d7cfc760657dd9bd9f.

Conflicts:
    code/modules/reagents/Chemistry-Reagents.dm

Revert "Made Cyanide more deadly, added OD to Hyperzine"

This reverts commit 1cb87e07cfdddc89c9452fe58ae41629226dea65.
