### PR TITLE
fix for customizable foods

### DIFF
--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -1,3 +1,5 @@
+/*
+
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/attackby(obj/item/W as obj, mob/user as mob)
 
 	if(istype(W,/obj/item/weapon/shard) || istype(W,/obj/item/weapon/reagent_containers/food/snacks))
@@ -99,3 +101,4 @@
 		H << "\red You lacerate your mouth on a [shard.name] in the sandwich!"
 		H.adjustBruteLoss(5) //TODO: Target head if human.
 	..()
+*/


### PR DESCRIPTION
names - no more meat, meat and egg sandwich sandwich sandwich type names
- this would now be an egg and double meat triple decker sandwich

commented sandwich.dm out. was almost duplicate code, but if a sandwich
was being made with a shard or customizable food, it was making it a
different object (/food/snacks/csandwich instead of
food/snacks/customizable/sandwich), only thing it processed that the
other didn't was if there was a shard in the food, which is now dealt
with in customizable

Would have deleted sandwich.dm, but for some reason my dmi adds a load of files and changes the path for detective to Detective when I compile, so trying to avoid including it in PR's where possible
