### PR TITLE
Allows the insertion of pipework into walls

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -480,6 +480,39 @@
 		place_poster(W,user)
 		return
 
+	//Bone White - Place pipes on walls
+	else if(istype(W,/obj/item/pipe))
+		var/obj/item/pipe/V = W
+		if(V.pipe_type != -1) // ANY PIPE
+			var/obj/item/pipe/P = W
+
+			playsound(get_turf(src), 'sound/weapons/circsawhit.ogg', 50, 1)
+			user.visible_message( \
+				"[user] starts drilling a hole in \the [src].", \
+				"\blue You start drilling a hole in \the [src].", \
+				"You hear ratchet.")
+			if (do_after(user, 80))
+				user.visible_message( \
+					"[user] drills a hole in \the [src] and pushes \a [P] into the void", \
+					"\blue You have finished drilling in \the [src] and push the [P] into the void.", \
+					"You hear ratchet.")
+				/*
+				new /obj/item/pipe(loc, make_from=src)
+				for (var/obj/machinery/meter/meter in T)
+					if (meter.target == src)
+						new /obj/item/pipe_meter(T)
+						del(meter)
+				qdel(src)
+				*/
+				user.drop_item()
+				P.dir = user.dir
+				P.x = src.x
+				P.y = src.y
+				P.z = src.z
+				P.loc = src
+				P.level = 2
+		return
+
 	else
 		return attack_hand(user)
 	return

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -311,6 +311,39 @@
 		place_poster(W,user)
 		return
 
+	//Bone White - Place pipes on walls
+	else if(istype(W,/obj/item/pipe))
+		var/obj/item/pipe/V = W
+		if(V.pipe_type != -1) // ANY PIPE
+			var/obj/item/pipe/P = W
+
+			playsound(get_turf(src), 'sound/weapons/circsawhit.ogg', 50, 1)
+			user.visible_message( \
+				"[user] starts drilling a hole in \the [src].", \
+				"\blue You start drilling a hole in \the [src].", \
+				"You hear ratchet.")
+			if (do_after(user, 80))
+				user.visible_message( \
+					"[user] drills a hole in \the [src] and pushes \a [P] into the void", \
+					"\blue You have finished drilling in \the [src] and push the [P] into the void.", \
+					"You hear ratchet.")
+				/*
+				new /obj/item/pipe(loc, make_from=src)
+				for (var/obj/machinery/meter/meter in T)
+					if (meter.target == src)
+						new /obj/item/pipe_meter(T)
+						del(meter)
+				qdel(src)
+				*/
+				user.drop_item()
+				P.dir = user.dir
+				P.x = src.x
+				P.y = src.y
+				P.z = src.z
+				P.loc = src
+				P.level = 2
+		return
+
 	//Finally, CHECKING FOR FALSE WALLS if it isn't damaged
 	else if(!d_state)
 		return attack_hand(user)


### PR DESCRIPTION
Pipes will be visible above the wall, allows for easier atmos repairs.
Atmos pipes installed this way can be wrenched into place, then unwrenched as normal.  Walls are
unaffected. Unwrenched pipes on walls can be picked up / dragged as expected
