### PR TITLE
Machine people fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -104,10 +104,11 @@
 
 
 /mob/living/carbon/human/adjustCloneLoss(var/amount)
-	..()
 
 	if(species.flags & IS_SYNTHETIC)
 		return
+
+	..()
 
 	var/heal_prob = max(0, 80 - getCloneLoss())
 	var/mut_prob = min(80, getCloneLoss()+10)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -640,9 +640,9 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			var/obj/item/device/suit_cooling_unit/CU = s_store
 			CU.cool_mob(src)
 
-		if (species.flags & IS_SYNTHETIC)
-			bodytemperature += species.synth_temp_gain		//that CPU/posibrain just keeps putting out heat.
-			return
+//		if (species.flags & IS_SYNTHETIC)
+//			bodytemperature += species.synth_temp_gain		//that CPU/posibrain just keeps putting out heat.		// commented out as making synthetics unplayable until cooling system sorted out
+//			return
 
 		var/body_temperature_difference = species.body_temperature - bodytemperature
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -593,6 +593,16 @@
 
 	flesh_color = "#AAAAAA"
 
+/datum/species/machine/handle_death(var/mob/living/carbon/human/H)
+	for(var/organ_name in H.organs_by_name)
+		if (organ_name == "head")			// do the head last as that's when the user will be transfered to the posibrain
+			continue
+		var/datum/organ/external/O = H.organs_by_name[organ_name]
+		if((O.body_part != UPPER_TORSO) && (O.body_part != LOWER_TORSO))  // We're making them fall apart, not gibbing them!
+			O.droplimb(1)
+	var/datum/organ/external/O = H.organs_by_name["head"]
+	O.droplimb(1)
+
 //Species unarmed attacks
 
 /datum/unarmed_attack

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -138,7 +138,8 @@
 		//If there are still hurties to dispense
 		if (burn || brute)
 			if (status & ORGAN_ROBOT)
-				droplimb(1) //Robot limbs just kinda fail at full damage.
+				if(body_part != UPPER_TORSO && body_part != LOWER_TORSO)          // as below, getting hit on the chest shouldn't gib you even if you've got a robotic chest
+					droplimb(1) //Robot limbs just kinda fail at full damage.
 			else
 				//List organs we can pass it to
 				var/list/datum/organ/external/possible_points = list()
@@ -585,7 +586,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(status & ORGAN_DESTROYED)
 		if(body_part == UPPER_TORSO)
 			return
-
+		if(body_part == LOWER_TORSO)
+			return
 		src.status &= ~ORGAN_BROKEN
 		src.status &= ~ORGAN_BLEEDING
 		src.status &= ~ORGAN_SPLINTED


### PR DESCRIPTION
Disables overheating as most players reporting it makes machine people
unplayable

Fixes machine people's immunity to clone damage

Ensures machine people fall apart and consiousness transferred to
posibrain properly on 'death'

Prevents robotic chest and groin being seperated which was leading to an
unrepairable body
