### PR TITLE
Added procedural slow to EVA suits

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,6 +4,21 @@
 	if(species && species.flags & IS_SLOW)
 		tally = 5
 
+	//Bone White - added additional slow for wearing a rig suit.  Does not stack with having IS_SLOW flag (Diona)
+	if(wear_suit && istype(wear_suit,/obj/item/clothing/suit/space))
+		var/datum/gas_mixture/environment = loc.return_air()
+		var/local_pressure = environment.return_pressure()
+		switch (local_pressure)
+			if(20 to 40)
+				tally = 1
+			if(40 to 60)
+				tally = 2
+			if(60 to 80)
+				tally = 3
+			if(80 to 9999999)
+				tally = 4
+
+
 	if (istype(loc, /turf/space)) return -1 // It's hard to be slowed down in space by... anything
 
 	if(embedded_flag)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -15,7 +15,7 @@
 				tally = 2
 			if(60 to 80)
 				tally = 3
-			if(80 to 9999999)
+			if(80 to INFINITY)
 				tally = 4
 
 


### PR DESCRIPTION
Slow increases as pressure around them increases.  At higher than 80kPa
the slow is 4 units (as compared to diona's natural slow of 5)
