### PR TITLE
Further atmos changes

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -1,7 +1,7 @@
 obj/machinery/atmospherics/trinary/filter
 	icon = 'icons/obj/atmospherics/filter.dmi'
 	icon_state = "intact_off"
-	density = 1
+	density = 0
 
 	name = "Gas filter"
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -1,7 +1,7 @@
 obj/machinery/atmospherics/trinary/mixer
 	icon = 'icons/obj/atmospherics/mixer.dmi'
 	icon_state = "intact_off"
-	density = 1
+	density = 0
 
 	name = "Gas mixer"
 

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -4,6 +4,7 @@ obj/machinery/atmospherics/pipe
 	var/datum/pipeline/parent
 
 	var/volume = 0
+	var/frozen = 0 //used by the pipe freezer
 	force = 20
 
 	layer = 2.4 //under wires with their 2.44
@@ -1176,6 +1177,7 @@ obj/machinery/atmospherics/pipe
 
 
 obj/machinery/atmospherics/pipe/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
+
 	if (istype(src, /obj/machinery/atmospherics/pipe/tank))
 		return ..()
 	if (istype(src, /obj/machinery/atmospherics/pipe/vent))
@@ -1203,18 +1205,55 @@ obj/machinery/atmospherics/pipe/attackby(var/obj/item/weapon/W as obj, var/mob/u
 		update_icon()
 		return 1
 
+	if (istype(W, /obj/item/device/pipe_freezer))
+		if(!src.frozen) // If the pipe is not already frozen
+			user << "\red You begin to freeze the [src]"
+			if (do_after(user, 60))
+				user.visible_message( \
+					"[user] freezes \the [src].", \
+					"\blue You finished freezing \the [src].", \
+					"You hear the hiss of gas.")
+				src.frozen = 1
+				spawn (200)
+					src.frozen = 0
+					src.visible_message( \
+					"\the ice arounds the [src] melts.", \
+					"\blue Your frozen [src] has thawed.", \
+					"You hear dripping water.")
+
+		add_fingerprint(user)
+		return 1
+
 	if (!istype(W, /obj/item/weapon/wrench))
 		return ..()
 	var/turf/T = src.loc
 	if (level==1 && isturf(T) && T.intact)
 		user << "\red You must remove the plating first."
 		return 1
+
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
-		user << "\red You cannot unwrench this [src], it too exerted due to internal pressure."
-		add_fingerprint(user)
-		return 1
+		if (!src.frozen) // If the pipe is not frozen
+			user << "\red You cannot unwrench this [src], it too exerted due to internal pressure."
+			add_fingerprint(user)
+			return 1
+		else // If the pipe is frozen
+			playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
+			user << "\blue You begin to unfasten \the [src] between the frozen segments..."
+			if (do_after(user, 40))
+				user.visible_message( \
+					"[user] unfastens \the [src].", \
+					"\blue You have unfastened \the [src].", \
+					"You hear ratchet.")
+				new /obj/item/pipe(loc, make_from=src)
+				for (var/obj/machinery/meter/meter in T)
+					if (meter.target == src)
+						new /obj/item/pipe_meter(T)
+						del(meter)
+				qdel(src)
+			return 1
+
 	playsound(get_turf(src), 'sound/items/Ratchet.ogg', 50, 1)
 	user << "\blue You begin to unfasten \the [src]..."
 	if (do_after(user, 40))

--- a/code/game/objects/items/devices/pipe_freezer.dm
+++ b/code/game/objects/items/devices/pipe_freezer.dm
@@ -1,0 +1,5 @@
+/obj/item/device/pipe_freezer
+	name = "Pipe Freezer"
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "labeler1"
+	item_state = "flight"


### PR DESCRIPTION
mixers and filters no longer have density = 1, so mobs can walk over
them.
new item: pipe freezer, can temporarily freeze pipes to allow
unwrenching when over the threshold internal pressure
note: has a temporary skin of hand labeler, needs a new sprite really.
