### PR TITLE
Rigid suit equip delay rework

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -151,8 +151,17 @@
 		//canremove==0 means that object may not be removed. You can still wear it. This only applies to clothing. /N
 		if(!src.canremove)
 			return 0
-		else
 
+		if(istype(user,/mob/living/carbon/human))
+			if(istype(src, /obj/item/clothing/suit/space/rig)) // If the item to be unequipped is a rigid suit
+				if(user.delay_clothing_u_equip(src) == 0)
+					return 0
+			else
+				user.u_equip(src)
+		else
+			user.u_equip(src)
+
+		/*
 			if(istype(user,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = user
 				if(istype(src, /obj/item/clothing/suit/space/rig)) // If the item to unequip item is a rigid suit
@@ -186,8 +195,7 @@
 							H << "\red \The [src] is too fiddly to remove whilst moving."
 							return 0
 					H << "\blue You finish removing the [src]."
-
-			user.u_equip(src)
+		*/
 	else
 		if(isliving(src.loc))
 			return 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,10 +1,13 @@
 /obj/item/clothing
 	name = "clothing"
 	var/list/species_restricted = null //Only these species can wear this kit.
+	var/equip_time = 0
+	var/equipping = 0
+	var/rig_restrict_helmet = 0 // Stops the user from equipping a rig helmet without attaching it to the suit first.
 
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(M as mob, slot)
-
+/*
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		if(istype(src, /obj/item/clothing/head/helmet/space/rig)) // If the item to be equipped is a rigid suit helmet
@@ -39,7 +42,7 @@
 					H << "\red \The [src] is too fiddly to fasten whilst moving. \..."
 					return 0
 			M << "\blue You have finished fastening the [src]'s seals."
-
+*/
 	//if we can equip the item anyway, don't bother with species_restricted (aslo cuts down on spam)
 	if (!..())
 		return 0

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -57,7 +57,7 @@
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
 	icon_state = "rig0-engineering"
 	item_state = "eng_helm"
-	var/equip_time = 60 // Bone White - time to equip/unequip. see /obj/item/attack_hand (items.dm) and /obj/item/clothing/mob_can_equip (clothing.dm)
+	rig_restrict_helmet = 1
 	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 	allowed = list(/obj/item/device/flashlight)
 	var/brightness_on = 4 //luminosity when on
@@ -103,7 +103,7 @@
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
 	icon_state = "rig-engineering"
 	item_state = "eng_hardsuit"
-	var/equip_time = 100 // Bone White - time to equip/unequip. see /obj/item/attack_hand (items.dm) and /obj/item/clothing/mob_can_equip (clothing.dm)
+	equip_time = 100 // Bone White - time to equip/unequip. see /obj/item/attack_hand (items.dm) and /obj/item/clothing/mob_can_equip (clothing.dm)
 	slowdown = 4
 	armor = list(melee = 30, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -138,14 +138,6 @@
 	if(hand)	return drop_l_hand(Target)
 	else		return drop_r_hand(Target)
 
-
-
-
-
-
-
-
-
 //TODO: phase out this proc
 /mob/proc/before_take_item(var/obj/item/W)	//TODO: what is this?
 	W.loc = null
@@ -154,6 +146,27 @@
 	update_icons()
 	return
 
+/mob/proc/delay_clothing_u_equip(obj/item/clothing/X as obj) // Bone White - delays unequipping by parameter.  Requires W to be /obj/item/clothing/
+
+	if(!istype(X)) return 0
+
+	if(X.equipping == 1) return 0 // Item is already being (un)equipped
+
+	var/tempX = usr.x
+	var/tempY = usr.y
+	usr << "\blue You start unequipping the [X]."
+	X.equipping = 1
+	var/equip_time = round(X.equip_time/10)
+	var/i
+	for(i=1; i<=equip_time; i++)
+		sleep (10) // Check if they've moved every 10 time units
+		if ((tempX != usr.x) || (tempY != usr.y))
+			src << "\red \The [X] is too fiddly to unequip whilst moving."
+			X.equipping = 0
+			return 0
+	u_equip(X)
+	usr << "\blue You have finished unequipping the [X]."
+	X.equipping = 0
 
 /mob/proc/u_equip(W as obj)
 	if (W == r_hand)


### PR DESCRIPTION
now uses a couple of new procs, allowing for per-suit tweaking of time.
You now cannot equip eva helms without first attaching them to the suit
(target head use helmet on suit)
