### PR TITLE
Hostile Environments Reblance

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1111,6 +1111,26 @@
 		src.custom_pain("You feel a stabbing pain in your chest!", 1)
 		L.damage = L.min_bruised_damage
 
+//Gave the rupture_lung() call it's own proc to have much more control over it.
+/mob/living/carbon/human/proc/try_lung_rupture(argBreath)
+	var/datum/gas_mixture/environment = loc.return_air()
+	var/datum/gas_mixture/breath = argBreath	
+	var/pressure = environment.return_pressure()
+	var/adjusted_pressure = calculate_affecting_pressure(pressure)
+	
+	//High kPa
+	if(!is_lung_ruptured() && breath.total_moles > BREATH_MOLES * 5)
+		if(prob(5))
+			rupture_lung()
+		return
+	//Low kPa
+	else if(!is_lung_ruptured() && internal && adjusted_pressure <= species.hazard_low_pressure)
+		if(internal.distribute_pressure >= species.warning_low_pressure)
+			if(prob(33))
+				rupture_lung()
+			return
+	else
+		return
 /*
 /mob/living/carbon/human/verb/simulate()
 	set name = "sim"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -395,27 +395,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				if(damage && organs.len)
 					var/datum/organ/external/O = pick(organs)
 					if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage)
-
-	//Gave the rupture_lung() call it's own proc to have much more control over it.
-	proc/try_lung_rupture(argBreath)
-		var/datum/gas_mixture/environment = loc.return_air()
-		var/datum/gas_mixture/breath = argBreath	
-		var/pressure = environment.return_pressure()
-		var/adjusted_pressure = calculate_affecting_pressure(pressure)
-		
-		//High kPa
-		if(!is_lung_ruptured() && breath.total_moles > BREATH_MOLES * 5)
-			if(prob(5))
-				rupture_lung()
-			return
-		//Low kPa
-		else if(!is_lung_ruptured() && internal && adjusted_pressure <= species.hazard_low_pressure)
-			if(internal.distribute_pressure >= species.warning_low_pressure)
-				if(prob(33))
-					rupture_lung()
-				return
-		else
-			return
 	
 	proc/breathe()
 		if(reagents.has_reagent("lexorin")) return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -36,6 +36,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	var/do_deferred_species_setup=0
 	var/exposedtimenow = 0
 	var/firstexposed = 0
+	var/last_message = 0
 
 // Doing this during species init breaks shit.
 /mob/living/carbon/human/proc/DeferredSpeciesSetup()
@@ -276,6 +277,35 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			// as cloneloss
 			adjustCloneLoss(0.1)
 
+	//Makes Space a little more evil, simulates that space is full of errent high energy particles waiting to tear you up.
+	proc/cosmic_radiation()
+		var/ax = x
+		var/ay = y
+		
+		if(istype(loc, /turf/space))
+			if(!(getarmor("chest", "rad") > 0))
+				if(prob(33))
+					apply_effect((rand(3,7)),IRRADIATE,0)
+			//Thank you to whoever wrote the vampire's sun code.
+			if(!(wear_suit && (wear_suit.flags & STOPSPRESSUREDMAGE)) && !(species.flags & RAD_ABSORB))
+				for(var/i = 1 to 20)
+					ax += sun.dx
+					ay += sun.dy
+
+					var/turf/T = locate( round(ax,0.5),round(ay,0.5),z)
+
+					if(T.x == 1 || T.x==world.maxx || T.y==1 || T.y==world.maxy)
+						break
+
+					if(T.density)
+						return
+						
+				var/datum/organ/external/O = pick(organs)
+				apply_damage(3, BURN, O)  
+				if(world.time - last_message > 5)
+					src << "\red You feel the intense heat of the sun giving you a harsh sunburn."
+					last_message = world.time
+			
 	proc/handle_mutations_and_radiation()
 
 		if(species.flags & IS_SYNTHETIC) //Robots don't suffer from mutations or radloss.
@@ -285,6 +315,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			if((M_RESIST_HEAT in mutations) || (prob(1)))
 				heal_organ_damage(0,1)
 
+		cosmic_radiation()
 
 		for(var/datum/dna/gene/gene in dna_genes)
 			if(!gene.block)
@@ -365,6 +396,27 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 					var/datum/organ/external/O = pick(organs)
 					if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage)
 
+	//Gave the rupture_lung() call it's own proc to have much more control over it.
+	proc/try_lung_rupture(argBreath)
+		var/datum/gas_mixture/environment = loc.return_air()
+		var/datum/gas_mixture/breath = argBreath	
+		var/pressure = environment.return_pressure()
+		var/adjusted_pressure = calculate_affecting_pressure(pressure)
+		
+		//High kPa
+		if(!is_lung_ruptured() && breath.total_moles > BREATH_MOLES * 5)
+			if(prob(5))
+				rupture_lung()
+			return
+		//Low kPa
+		else if(!is_lung_ruptured() && internal && adjusted_pressure <= species.hazard_low_pressure)
+			if(internal.distribute_pressure >= species.warning_low_pressure)
+				if(prob(33))
+					rupture_lung()
+				return
+		else
+			return
+	
 	proc/breathe()
 		if(reagents.has_reagent("lexorin")) return
 		if(M_NO_BREATH in mutations) return // No breath mutation means no breathing.
@@ -388,6 +440,8 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		else
 			//First, check for air from internal atmosphere (using an air tank and mask generally)
 			breath = get_breath_from_internal(BREATH_VOLUME) // Super hacky -- TLE
+			if(breath)
+				try_lung_rupture(breath)
 			//breath = get_breath_from_internal(0.5) // Manually setting to old BREATH_VOLUME amount -- TLE
 
 			//No breath from internal atmosphere so get breath from location
@@ -405,12 +459,9 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 					breath_moles = environment.total_moles()*BREATH_PERCENTAGE
 
 					breath = loc.remove_air(breath_moles)
-
-					if(!is_lung_ruptured())
-						if(!breath || breath.total_moles < BREATH_MOLES / 5 || breath.total_moles > BREATH_MOLES * 5)
-							if(prob(5))
-								rupture_lung()
-
+					
+					try_lung_rupture(breath)			
+					
 					// Handle chem smoke effect  -- Doohl
 					var/block = 0
 					if(wear_mask)
@@ -600,7 +651,8 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			pressure_alert = -1
 		else
 			if( !(M_RESIST_COLD in mutations))
-				take_overall_damage(brute=LOW_PRESSURE_DAMAGE, used_weapon = "Low Pressure")
+				//Low pressure really cant deal much pysical damage but would be pretty painful. -IndexLP
+				apply_damage(LOW_PRESSURE_DAMAGE+1, HALLOSS)
 				pressure_alert = -2
 			else
 				pressure_alert = -1
@@ -1043,12 +1095,16 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				for(var/atom/a in hallucinations)
 					del a
 
-				if(halloss > 100)
+				if(halloss > 100 && pressure_alert != -2)
 					src << "<span class='notice'>You're in too much pain to keep going...</span>"
 					for(var/mob/O in oviewers(src, null))
 						O.show_message("<B>[src]</B> slumps to the ground, too weak to continue fighting.", 1)
 					Paralyse(10)
 					setHalLoss(99)
+				if(halloss > 100 && pressure_alert == -2)
+					src << "<span class='notice'>You're in too much pain to keep going...</span>"
+					Paralyse(10)
+					setHalLoss(95)
 
 			if(paralysis)
 				AdjustParalysis(-1)


### PR DESCRIPTION
#### Low pressure

Low pressure environments themselves are made less deadly, a lung can only be punctured if a gas is in your lungs (from internals for example) and only if the pressure from the source of the air is above 50kPa, so a player can still wear pure oxygen (or nitrogen) internals, but an air mix would more than likely cause a ruptured lung due to the need to keep it at a high distribution pressure. Rupturing lungs in high pressure environments acts the same as always.

In addition to the changes to low pressure lung ruptures, low kPa environments no longer deals brute damage to external organs but rather deal halloss to represent the pain from having your body expand despite the fact it wouldn't cause much if any actually damage.
#### Space

Two major changes to space make it much more deadly when combined with the switch to halloss damage in low pressure environments. 

First: All areas of open space irradiate unshielded mobs (including players as well of course), although any torso based radiation shielding will completely cancel the irradiation.

Second: Areas of space not in the station shadow (as calculated using a new proc based on the the vampire.dm check_sun() proc) cause mobs to take heat damage. Any torso based suit with the 'STOPSPRESSUREDMAGE' flag is capable of negating this damage. Due to this damage coming from the sun's non-ionizing radiation any mob with RAD_ABSORB ignores this damage, although they get no benefit.
##### Misc. and Notes

These changes were done partially to make the simulation more robust and mimic real-world physics better and partially to make space the inhospitable place it should be. All changes were made with race lore in mind and all races keep their identity and special abilities. This radiation wont affect IPCs (this includes the burn effect as of right now as well), Vox wont take the low kPa halloss as they never enter/pass the hazard_low_pressure threshold for their species, and diona still interact with this new radiation in the way they interact with all other radiation-- for instance. I don't know quite why because I didn't look into it but I tested spacepods and they behave as one would expect, they prevent the driver from both the burn and irradiation, so pod pilots will be unaffected by these changes so long as they stay in their pods or are wearing the right protection when they eject into space.
