### PR TITLE
Cleanup of internal organs

### DIFF
--- a/code/ZAS/Plasma.dm
+++ b/code/ZAS/Plasma.dm
@@ -126,7 +126,7 @@ obj/var/contaminated = 0
 /mob/living/carbon/human/proc/burn_eyes()
 	//The proc that handles eye burning.
 	if(prob(20)) src << "\red Your eyes burn!"
-	var/datum/organ/internal/eyes/E = internal_organs["eyes"]
+	var/datum/organ/internal/eyes/E = internal_organs_by_name["eyes"]
 	E.damage += 2.5
 	eye_blurry = min(eye_blurry+1.5,50)
 	if (prob(max(0,E.damage - 15) + 1) && !eye_blind)

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -502,7 +502,8 @@
 				O.trace_chemicals = list()
 				O.wounds = list()
 				O.wound_update_accuracy = 1
-			for(var/datum/organ/internal/IO in H.internal_organs)
+			for(var/n in H.internal_organs_by_name)
+				var/datum/organ/internal/IO = H.internal_organs_by_name[n]
 				IO.damage = 0
 				IO.trace_chemicals = list()
 			H.updatehealth()

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -393,13 +393,9 @@
 						else
 							dat += "<td>[e.display_name]</td><td>-</td><td>-</td><td>Not Found</td>"
 						dat += "</tr>"
-					for(var/datum/organ/internal/i in occupant.internal_organs)
-						var/mech = ""
-						if(i.robotic == 1)
-							mech = "Assisted:"
-						if(i.robotic == 2)
-							mech = "Mechanical:"
-
+					for(var/n in occupant.internal_organs_by_name)
+						var/datum/organ/internal/i = occupant.internal_organs_by_name[n]
+						var/mech = i.desc
 						var/infection = "None"
 						switch (i.germ_level)
 							if (1 to INFECTION_LEVEL_ONE + 200)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -660,10 +660,10 @@
 		var/datum/organ/internal/eyes/eyes = H.internal_organs_by_name["eyes"]
 		if(!eyes)
 			return
-		eyes.damage += rand(3,4)
+		eyes.take_damage(rand(3,4), 1)
 		if(eyes.damage >= eyes.min_bruised_damage)
 			if(M.stat != 2)
-				if(eyes.robotic <= 1) //robot eyes bleeding might be a bit silly
+				if(!(istype(eyes, /datum/organ/internal/eyes/robotic)) || istype(eyes, /datum/organ/internal/eyes/assisted)) //robot eyes bleeding might be a bit silly
 					M << "\red Your eyes start to bleed profusely!"
 			if(prob(50))
 				if(M.stat != 2)

--- a/code/modules/events/organ_failure.dm
+++ b/code/modules/events/organ_failure.dm
@@ -13,7 +13,7 @@ datum/event/organ_failure/announce()
 datum/event/organ_failure/start()
 	var/list/candidates = list()	//list of candidate keys
 	for(var/mob/living/carbon/human/G in player_list)
-		if(G.mind && G.mind.current && G.mind.current.stat != DEAD && G.health > 70 && G.internal_organs)
+		if(G.mind && G.mind.current && G.mind.current.stat != DEAD && G.health > 70 && G.internal_organs_by_name)
 			candidates += G
 	if(!candidates.len)	return
 	candidates = shuffle(candidates)//Incorporating Donkie's list shuffle
@@ -24,7 +24,8 @@ datum/event/organ_failure/start()
 		var/acute = prob(15)
 		if (prob(75))
 			//internal organ infection
-			var/datum/organ/internal/I = pick(C.internal_organs)
+			var/org = pick(C.internal_organs_by_name)
+			var/datum/organ/internal/I = C.internal_organs_by_name[org]
 
 			if (acute)
 				I.germ_level = max(INFECTION_LEVEL_TWO, I.germ_level)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1090,7 +1090,8 @@
 					H.brainmob.mind.transfer_to(src)
 					del(H)
 
-	for(var/datum/organ/internal/I in internal_organs)
+	for(var/name in internal_organs_by_name)
+		var/datum/organ/internal/I = internal_organs_by_name[name]
 		I.damage = 0
 
 	for (var/ID in virus2)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -14,7 +14,7 @@
 	if( (((100 - total_burn) < config.health_threshold_dead) && stat == DEAD) && (!species.flags & IS_SYNTHETIC))//100 only being used as the magic human max health number, feel free to change it if you add a var for it -- Urist
 		ChangeToHusk()
 	if (species.flags & IS_SYNTHETIC)
-		var/datum/organ/external/H = get_organ(head)
+		var/datum/organ/external/H = organs_by_name["head"]
 		if (!H.amputated)
 			if ((health >= (config.health_threshold_dead/100*75)) && stat == DEAD)  //need to get them 25% away from death point before reviving them
 				dead_mob_list -= src

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -179,7 +179,6 @@ emp_act
 		if(O.status & ORGAN_DESTROYED)	continue
 		O.emp_act(severity)
 		for(var/datum/organ/internal/I  in O.internal_organs)
-			if(I.robotic == 0)  continue
 			I.emp_act(severity)
 	..()
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -998,7 +998,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 			// Sobering multiplier.
 			// Sober block grants quadruple the alcohol metabolism.
-			var/sober_str=!(M_SOBER in mutations)?1:4
+//			var/sober_str=!(M_SOBER in mutations)?1:4
 
 			updatehealth()	//TODO
 			if(!in_stasis)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -82,28 +82,17 @@
 	H.organs_by_name["r_foot"] = new/datum/organ/external/r_foot(H.organs_by_name["r_leg"])
 
 	if (name!="Slime People")
-		H.internal_organs = list()
-		H.internal_organs_by_name["heart"] = new/datum/organ/internal/heart(H)
-		H.internal_organs_by_name["lungs"] = new/datum/organ/internal/lungs(H)
-		H.internal_organs_by_name["liver"] = new/datum/organ/internal/liver(H)
-		H.internal_organs_by_name["kidney"] = new/datum/organ/internal/kidney(H)
-		H.internal_organs_by_name["brain"] = new/datum/organ/internal/brain(H)
-		H.internal_organs_by_name["eyes"] = new/datum/organ/internal/eyes(H)
+		new/datum/organ/internal/heart(H)
+		new/datum/organ/internal/lungs(H)
+		new/datum/organ/internal/liver(H)
+		new/datum/organ/internal/kidney(H)
+		new/datum/organ/internal/brain(H)
+		new/datum/organ/internal/eyes(H)
 
-	for(var/name in H.organs_by_name)
-		H.organs += H.organs_by_name[name]
-
-	for(var/datum/organ/external/O in H.organs)
+	for(var/n in H.organs_by_name)
+		var/datum/organ/external/O = H.organs_by_name[n]
 		O.owner = H
-
-	if(flags & IS_SYNTHETIC)
-		for(var/datum/organ/external/E in H.organs)
-			if(E.status & ORGAN_CUT_AWAY || E.status & ORGAN_DESTROYED) continue
-			E.status |= ORGAN_ROBOT
-		for(var/datum/organ/internal/I in H.internal_organs)
-			I.mechanize()
-
-
+		H.organs += O
 	return
 
 /datum/species/proc/handle_breath(var/datum/gas_mixture/breath, var/mob/living/carbon/human/H)
@@ -600,6 +589,38 @@
 			O.droplimb(1)
 	var/datum/organ/external/O = H.organs_by_name["head"]
 	O.droplimb(1)
+
+/datum/species/machine/create_organs(var/mob/living/carbon/human/H)
+
+	H.organs = new /list()
+	H.organs_by_name["chest"] = new/datum/organ/external/chest()
+	H.organs_by_name["groin"] = new/datum/organ/external/groin(H.organs_by_name["chest"])
+	H.organs_by_name["head"] = new/datum/organ/external/head(H.organs_by_name["chest"])
+	H.organs_by_name["l_arm"] = new/datum/organ/external/l_arm(H.organs_by_name["chest"])
+	H.organs_by_name["r_arm"] = new/datum/organ/external/r_arm(H.organs_by_name["chest"])
+	H.organs_by_name["r_leg"] = new/datum/organ/external/r_leg(H.organs_by_name["groin"])
+	H.organs_by_name["l_leg"] = new/datum/organ/external/l_leg(H.organs_by_name["groin"])
+	H.organs_by_name["l_hand"] = new/datum/organ/external/l_hand(H.organs_by_name["l_arm"])
+	H.organs_by_name["r_hand"] = new/datum/organ/external/r_hand(H.organs_by_name["r_arm"])
+	H.organs_by_name["l_foot"] = new/datum/organ/external/l_foot(H.organs_by_name["l_leg"])
+	H.organs_by_name["r_foot"] = new/datum/organ/external/r_foot(H.organs_by_name["r_leg"])
+
+	new/datum/organ/internal/heart/robotic(H)
+	new/datum/organ/internal/lungs/robotic(H)
+	new/datum/organ/internal/liver/robotic(H)
+	new/datum/organ/internal/kidney/robotic(H)
+	new/datum/organ/internal/brain/robotic(H)
+	new/datum/organ/internal/eyes/robotic(H)
+
+
+	for(var/n in H.organs_by_name)
+		var/datum/organ/external/O = H.organs_by_name[n]
+		O.owner = H
+		if(!(O.status & ORGAN_CUT_AWAY || O.status & ORGAN_DESTROYED))
+			O.status |= ORGAN_ROBOT
+		H.organs += O
+	return
+
 
 //Species unarmed attacks
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -69,7 +69,8 @@
 			bad_external_organs += Ex
 
 	//processing internal organs is pretty cheap, do that first.
-	for(var/datum/organ/internal/I in internal_organs)
+	for(var/name in internal_organs_by_name)
+		var/datum/organ/internal/I = internal_organs_by_name[name]
 		I.process()
 
 	//Check arms and legs for existence

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -20,7 +20,7 @@
 
 	var/tmp/perma_injury = 0
 	var/tmp/destspawn = 0 //Has it spawned the broken limb?
-	var/tmp/amputated = 0 //Whether this has been cleanly amputated, thus causing no pain
+	var/amputated = 0 //Whether this has been cleanly amputated, thus causing no pain
 	var/min_broken_damage = 30
 
 	var/datum/organ/external/parent

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -20,7 +20,7 @@
 
 	var/tmp/perma_injury = 0
 	var/tmp/destspawn = 0 //Has it spawned the broken limb?
-	var/amputated = 0 //Whether this has been cleanly amputated, thus causing no pain
+	var/tmp/amputated = 0 //Whether this has been cleanly amputated, thus causing no pain
 	var/min_broken_damage = 30
 
 	var/datum/organ/external/parent

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -2,15 +2,15 @@
 				INTERNAL ORGANS
 ****************************************************/
 
-/mob/living/carbon/human/var/list/internal_organs = list()
-
 /datum/organ/internal
 	// amount of damage to the organ
 	var/damage = 0
 	var/min_bruised_damage = 10
 	var/min_broken_damage = 30
 	var/parent_organ = "chest"
-	var/robotic = 0 //For being a robot
+	var/desc = ""
+	var/list/emplevel = list(0,0,0)  // [1] is the highest amount of emp damage, [3] is the least
+	var/damagelevel = 1
 
 /datum/organ/internal/proc/rejuvenate()
 	damage=0
@@ -21,21 +21,19 @@
 /datum/organ/internal/proc/is_broken()
 	return damage >= min_broken_damage
 
-
-
 /datum/organ/internal/New(mob/living/carbon/human/H)
 	..()
-	var/datum/organ/external/E = H.organs_by_name[src.parent_organ]
-	if(E.internal_organs == null)
-		E.internal_organs = list()
-	E.internal_organs |= src
-	H.internal_organs |= src
-	src.owner = H
+	if(H)
+		var/datum/organ/internal/check = H.internal_organs_by_name[name]
+		if(check)
+			remove(H)
+		add(H)
+
 
 /datum/organ/internal/process()
 	//Process infections
 
-	if (robotic >= 2 || (owner.species && owner.species.flags & IS_PLANT))	//TODO make robotic internal and external organs separate types of organ instead of a flag
+	if (owner.species && owner.species.flags & IS_PLANT)
 		germ_level = 0
 		return
 
@@ -64,49 +62,42 @@
 				take_damage(1,silent=prob(30))
 
 /datum/organ/internal/proc/take_damage(amount, var/silent=0)
-	if(src.robotic == 2)
-		src.damage += amount * 0.8
-	else
-		src.damage += amount
+
+	damage += amount * damagelevel
 
 	var/datum/organ/external/parent = owner.get_organ(parent_organ)
 	if (!silent)
 		owner.custom_pain("Something inside your [parent.display_name] hurts a lot.", 1)
 
 /datum/organ/internal/proc/emp_act(severity)
-	switch(robotic)
-		if(0)
-			return
-		if(1)
-			switch (severity)
-				if (1.0)
-					take_damage(20,0)
-					return
-				if (2.0)
-					take_damage(7,0)
-					return
-				if(3.0)
-					take_damage(3,0)
-					return
-		if(2)
-			switch (severity)
-				if (1.0)
-					take_damage(40,0)
-					return
-				if (2.0)
-					take_damage(15,0)
-					return
-				if(3.0)
-					take_damage(10,0)
-					return
+
+	if(emplevel[1])
+		take_damage(emplevel[severity])
 
 /datum/organ/internal/proc/mechanize() //Being used to make robutt hearts, etc
-	robotic = 2
 
 /datum/organ/internal/proc/mechassist() //Used to add things like pacemakers, etc
-	robotic = 1
-	min_bruised_damage = 15
-	min_broken_damage = 35
+
+/datum/organ/internal/proc/remove(var/mob/living/carbon/human/H)
+	if(H)
+		var/datum/organ/internal/toremove = H.internal_organs_by_name[name]
+		if(toremove)
+			var/datum/organ/external/E = H.organs_by_name[toremove.parent_organ]
+			for (var/datum/organ/internal/I in E.internal_organs)
+				if (I == toremove)
+					I = null
+
+	return
+
+/datum/organ/internal/proc/add(var/mob/living/carbon/human/H)
+	var/datum/organ/external/P = H.organs_by_name[parent_organ]
+	if(P)
+		if(P.internal_organs == null)
+			P.internal_organs = list()
+		P.internal_organs += src
+	H.internal_organs_by_name[name] = src
+	owner = H
+	return
 
 /****************************************************
 				INTERNAL ORGANS DEFINES
@@ -116,85 +107,224 @@
 	name = "heart"
 	parent_organ = "chest"
 
+/datum/organ/internal/heart/robotic
+	damagelevel = 0.8
+	emplevel = list(40,15,10)
+	desc = "Mechanical"
+
+/datum/organ/internal/heart/robotic/process()
+	germ_level = 0
+	return
+
+/datum/organ/internal/heart/mechanize()
+	new /datum/organ/internal/heart/robotic(owner)
+	return
+
+/datum/organ/internal/heart/assisted
+	min_bruised_damage = 15
+	min_broken_damage = 35
+	emplevel = list(20,7,3)
+	desc = "Assisted"
+
+/datum/organ/internal/heart/mechassist()
+	new /datum/organ/internal/heart/assisted(owner)
+	return
 
 /datum/organ/internal/lungs
 	name = "lungs"
 	parent_organ = "chest"
 
-	process()
-		..()
-		if (germ_level > INFECTION_LEVEL_ONE)
-			if(prob(5))
-				owner.emote("cough")		//respitory tract infection
+/datum/organ/internal/lungs/process()
+	..()
+	if (germ_level > INFECTION_LEVEL_ONE)
+		if(prob(5))
+			owner.emote("cough")		//respitory tract infection
 
-		if(is_bruised())
-			if(prob(2))
-				spawn owner.emote("me", 1, "coughs up blood!")
-				owner.drip(10)
-			if(prob(4))
-				spawn owner.emote("me", 1, "gasps for air!")
-				owner.losebreath += 15
+	if(is_bruised())
+		if(prob(2))
+			spawn owner.emote("me", 1, "coughs up blood!")
+			owner.drip(10)
+		if(prob(4))
+			spawn owner.emote("me", 1, "gasps for air!")
+			owner.losebreath += 15
+
+/datum/organ/internal/lungs/robotic
+	damagelevel = 0.8
+	emplevel = list(40,15,10)
+	desc = "Mechanical"
+
+/datum/organ/internal/lungs/robotic/process()
+	germ_level = 0
+	return
+
+/datum/organ/internal/lungs/mechanize()
+	new /datum/organ/internal/lungs/robotic(owner)
+	return
+
+/datum/organ/internal/lungs/assisted
+	min_bruised_damage = 15
+	min_broken_damage = 35
+	emplevel = list(20,7,3)
+	desc = "Assisted"
+
+/datum/organ/internal/lungs/mechassist()
+	new /datum/organ/internal/lungs/assisted(owner)
+	return
 
 /datum/organ/internal/liver
 	name = "liver"
 	parent_organ = "chest"
 	var/process_accuracy = 10
 
-	process()
-		..()
-		if (germ_level > INFECTION_LEVEL_ONE)
-			if(prob(1))
-				owner << "\red Your skin itches."
-		if (germ_level > INFECTION_LEVEL_TWO)
-			if(prob(1))
-				spawn owner.vomit()
+/datum/organ/internal/liver/process()
+	..()
+	if (germ_level > INFECTION_LEVEL_ONE)
+		if(prob(1))
+			owner << "\red Your skin itches."
+	if (germ_level > INFECTION_LEVEL_TWO)
+		if(prob(1))
+			spawn owner.vomit()
 
-		if(owner.life_tick % process_accuracy == 0)
-			if(src.damage < 0)
-				src.damage = 0
+	if(owner.life_tick % process_accuracy == 0)
+		if(src.damage < 0)
+			src.damage = 0
 
-			//High toxins levels are dangerous
-			if(owner.getToxLoss() >= 60 && !owner.reagents.has_reagent("anti_toxin"))
-				//Healthy liver suffers on its own
-				if (src.damage < min_broken_damage)
-					src.damage += 0.2 * process_accuracy
-				//Damaged one shares the fun
-				else
-					var/datum/organ/internal/O = pick(owner.internal_organs)
-					if(O)
-						O.damage += 0.2  * process_accuracy
+		//High toxins levels are dangerous
+		if(owner.getToxLoss() >= 60 && !owner.reagents.has_reagent("anti_toxin"))
+			//Healthy liver suffers on its own
+			if (src.damage < min_broken_damage)
+				src.damage += 0.2 * process_accuracy
+			//Damaged one shares the fun
+			else
+				var/datum/organ/internal/O = pick(owner.internal_organs_by_name)
+				if(O)
+					O.damage += 0.2  * process_accuracy
 
-			//Detox can heal small amounts of damage
-			if (src.damage && src.damage < src.min_bruised_damage && owner.reagents.has_reagent("anti_toxin"))
-				src.damage -= 0.2 * process_accuracy
+		//Detox can heal small amounts of damage
+		if (src.damage && src.damage < src.min_bruised_damage && owner.reagents.has_reagent("anti_toxin"))
+			src.damage -= 0.2 * process_accuracy
 
-			// Damaged liver means some chemicals are very dangerous
-			if(src.damage >= src.min_bruised_damage)
-				for(var/datum/reagent/R in owner.reagents.reagent_list)
-					// Ethanol and all drinks are bad
-					if(istype(R, /datum/reagent/ethanol))
-						owner.adjustToxLoss(0.1 * process_accuracy)
+		// Damaged liver means some chemicals are very dangerous
+		if(src.damage >= src.min_bruised_damage)
+			for(var/datum/reagent/R in owner.reagents.reagent_list)
+				// Ethanol and all drinks are bad
+				if(istype(R, /datum/reagent/ethanol))
+					owner.adjustToxLoss(0.1 * process_accuracy)
 
-				// Can't cope with toxins at all
-				for(var/toxin in list("toxin", "plasma", "sacid", "pacid", "cyanide", "lexorin", "amatoxin", "chloralhydrate", "carpotoxin", "zombiepowder", "mindbreaker"))
-					if(owner.reagents.has_reagent(toxin))
-						owner.adjustToxLoss(0.3 * process_accuracy)
+			// Can't cope with toxins at all
+			for(var/toxin in list("toxin", "plasma", "sacid", "pacid", "cyanide", "lexorin", "amatoxin", "chloralhydrate", "carpotoxin", "zombiepowder", "mindbreaker"))
+				if(owner.reagents.has_reagent(toxin))
+					owner.adjustToxLoss(0.3 * process_accuracy)
+
+/datum/organ/internal/liver/robotic
+	damagelevel = 0.8
+	emplevel = list(40,15,10)
+
+/datum/organ/internal/liver/robotic/process()
+	germ_level = 0
+	return
+
+/datum/organ/internal/liver/mechanize()
+	new /datum/organ/internal/liver/robotic(owner)
+	return
+
+/datum/organ/internal/liver/assisted
+	min_bruised_damage = 15
+	min_broken_damage = 35
+	emplevel = list(20,7,3)
+	desc = "Assisted"
+
+/datum/organ/internal/liver/mechassist()
+	new /datum/organ/internal/liver/assisted(owner)
+	return
 
 /datum/organ/internal/kidney
 	name = "kidney"
 	parent_organ = "chest"
 
+/datum/organ/internal/kidney/robotic
+	damagelevel = 0.8
+	emplevel = list(40,15,10)
+	desc = "Mechanical"
+
+/datum/organ/internal/kidney/robotic/process()
+	germ_level = 0
+	return
+
+/datum/organ/internal/kidney/mechanize()
+	new /datum/organ/internal/kidney/robotic(owner)
+	return
+
+/datum/organ/internal/kidney/assisted
+	min_bruised_damage = 15
+	min_broken_damage = 35
+	emplevel = list(20,7,3)
+	desc = "Assisted"
+
+/datum/organ/internal/kidney/mechassist()
+	new /datum/organ/internal/kidney/assisted(owner)
+	return
+
 /datum/organ/internal/brain
 	name = "brain"
 	parent_organ = "head"
+
+/datum/organ/internal/brain/robotic
+	damagelevel = 0.8
+	emplevel = list(40,15,10)
+	desc = "Mechanical"
+
+/datum/organ/internal/brain/robotic/process()
+	germ_level = 0
+	return
+
+/datum/organ/internal/brain/mechanize()
+	new /datum/organ/internal/brain/robotic(owner)
+	return
+
+/datum/organ/internal/brain/assisted
+	min_bruised_damage = 15
+	min_broken_damage = 35
+	emplevel = list(20,7,3)
+	desc = "Assisted"
+
+/datum/organ/internal/brain/mechassist()
+	new /datum/organ/internal/brain/assisted(owner)
+	return
 
 /datum/organ/internal/eyes
 	name = "eyes"
 	parent_organ = "head"
 
-	process() //Eye damage replaces the old eye_stat var.
-		..()
-		if(is_bruised())
-			owner.eye_blurry = 20
-		if(is_broken())
-			owner.eye_blind = 20
+/datum/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
+	..()
+	if(is_bruised())
+		owner.eye_blurry = 20
+	if(is_broken())
+		owner.eye_blind = 20
+
+/datum/organ/internal/eyes/robotic
+	damagelevel = 0.8
+	emplevel = list(40,15,10)
+	desc = "Mechanical"
+
+/datum/organ/internal/eyes/robotic/process()
+	germ_level = 0
+	if(is_bruised())
+		owner.eye_blurry = 20
+	if(is_broken())
+		owner.eye_blind = 20
+
+/datum/organ/internal/eyes/mechanize()
+	new /datum/organ/internal/eyes/robotic(owner)
+	return
+
+/datum/organ/internal/eyes/assisted
+	min_bruised_damage = 15
+	min_broken_damage = 35
+	emplevel = list(20,7,3)
+	desc = "Assisted"
+
+/datum/organ/internal/eyes/mechassist()
+	new /datum/organ/internal/eyes/assisted(owner)
+	return

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -102,7 +102,8 @@ mob/living/carbon/human/proc/handle_pain()
 		pain(damaged_organ.display_name, maxdam, 0)
 
 	// Damage to internal organs hurts a lot.
-	for(var/datum/organ/internal/I in internal_organs)
+	for(var/n in internal_organs_by_name)
+		var/datum/organ/internal/I = internal_organs_by_name[n]
 		if(I.damage > 2) if(prob(2))
 			var/datum/organ/external/parent = get_organ(I.parent_organ)
 			src.custom_pain("You feel a sharp pain in your [parent.display_name]", 1)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1910,7 +1910,8 @@ datum
 					var/mob/living/carbon/human/H = M
 
 					//Peridaxon is hard enough to get, it's probably fair to make this all internal organs
-					for(var/datum/organ/internal/I in H.internal_organs)
+					for(var/name in H.internal_organs_by_name)
+						var/datum/organ/internal/I = H.internal_organs_by_name[name]
 						if(I.damage > 0)
 							I.damage -= 0.20
 				..()
@@ -2804,7 +2805,7 @@ datum
 			description = "Finely shredded tea leaves, used for making tea."
 			reagent_state = SOLID
 			color = "#7F8400" // rgb: 127, 132, 0
-			
+
 		//Reagents used for plant fertilizers.
 		toxin/fertilizer
 			name = "fertilizer"

--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -111,7 +111,7 @@
 			B = new(target.loc)
 			B.transfer_identity(target)
 
-		target.internal_organs -= B
+		target.internal_organs_by_name -= B
 		target.internal_organs_by_name -= "brain"
 
 		target:brain_op_stage = 4.0

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -219,10 +219,10 @@
 				user.visible_message("[user] starts sealing the rupture in [target]'s lungs with regenerative membrane.", \
 				"You start mending the rupture in [target]'s lungs with regenerative membrane." )
 			if(heart.damage > 0)
-				if(heart.robotic < 2)
+				if(!heart.desc == "Mechanical")
 					user.visible_message("[user] starts mending the bruises on [target]'s heart with regenerative membrane.", \
 					"You start mending the bruises on [target]'s heart with regenerative membrane." )
-				if(heart.robotic == 2)
+				else
 					user.visible_message("\blue [user] attempts to repair [target]'s mechanical heart with regenerative membrane...", \
 					"\blue You attempt to repair [target]'s heart with regenerative membrane...")
 			if(liver.damage > 0)
@@ -237,10 +237,10 @@
 					user.visible_message("[user] starts covering the rupture in [target]'s lungs with the poultice.", \
 					"You start covering the rupture in [target]'s lungs with the poultice." )
 				if(heart.damage > 0)
-					if(heart.robotic < 2)
+					if(!heart.desc == "Mechanical")
 						user.visible_message("[user] starts mending the bruises on [target]'s heart with the poultice.", \
 						"You start mending the bruises on [target]'s heart with the poultice." )
-					if(heart.robotic == 2)
+					else
 						user.visible_message("\blue [user] attempts to repair [target]'s mechanical heart with \the [tool]...", \
 						"\blue You attempt to repair [target]'s heart with \the [tool]...")
 				if(liver.damage > 0)
@@ -254,10 +254,10 @@
 					"You start mending the rupture in [target]'s lungs \the [tool]." )
 			else
 				if(heart.damage > 0)
-					if(heart.robotic < 2)
+					if(!heart.desc == "Mechanical")
 						user.visible_message("[user] starts mending the bruises on [target]'s heart with \the [tool].", \
 						"You start mending the bruises on [target]'s heart with \the [tool]." )
-					if(heart.robotic == 2)
+					else
 						user.visible_message("\blue [user] attempts to repair [target]'s mechanical heart with \the [tool]...", \
 						"\blue You attempt to repair [target]'s heart with \the [tool]...")
 				if(liver.damage > 0)
@@ -281,7 +281,7 @@
 			lungs.damage = 0
 
 		if(heart.damage > 0)
-			if(heart.robotic == 2)
+			if(heart.desc == "Mechanical")
 				user.visible_message("\blue [user] pokes [target]'s mechanical heart with \the [tool].", \
 				"\red [target]'s heart is not organic, you cannot operate on it with \the [tool]!")
 			else
@@ -363,7 +363,7 @@
 		var/datum/organ/internal/heart/heart = target.internal_organs_by_name["heart"]
 
 		if(heart.damage > 0)
-			if(heart.robotic == 2)
+			if(heart.desc == "Mechanical")
 				user.visible_message("[user] starts mending the mechanisms on [target]'s heart with \the [tool].", \
 				"You start mending the mechanisms on [target]'s heart with \the [tool]." )
 			else
@@ -375,7 +375,7 @@
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/datum/organ/internal/heart/heart = target.internal_organs_by_name["heart"]
 		if(heart.damage > 0)
-			if(heart.robotic == 2)
+			if(heart.desc == "Mechanical")
 				user.visible_message("\blue [user] repairs [target]'s heart with \the [tool].", \
 				"\blue You repair [target]'s heart with \the [tool]." )
 				heart.damage = 0


### PR DESCRIPTION
Both internal and external organs are a mess, which is making
maintaining and updating them nasty, so I'm cleaning them up, this is
the first stage

mechanical and assisted internal organs are now an object type rather
than a var in the organ which makes it much cleaner and easier to adjust

removed duplicate list of internal organs as there's no reason to have
the same objects in 2 separate lists

made New() a lot cleaner and more robust

External organs will be next

Also does sort out the runtime caused by #398
