### PR TITLE
Support Jobs on ID Comp Fix

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -116,7 +116,6 @@ var/list/support_positions = list(
 	"Mime",
 	"Barber",
 	"Magistrate",
-	"Nanotrasen Representative",
 	"Nanotrasen Recruiter"
 )
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -107,6 +107,7 @@
 	data["science_jobs"] = format_jobs(science_positions)
 	data["security_jobs"] = format_jobs(security_positions)
 	data["support_jobs"] = format_jobs(support_positions)
+	data["civilian_jobs"] = format_jobs(civilian_positions)
 	data["special_jobs"] = format_jobs(whitelisted_positions)
 	data["centcom_jobs"] = format_jobs(get_all_centcom_jobs())
 

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -132,9 +132,6 @@
           <div id="all-value.jobs" style='display: none;'>
             <table>
               <tr>
-                <th></th><th>Command</th>
-              </tr>
-              <tr>
                 <th>Special</th>
                 <td>
                   {{:helper.link("Captain", '', {'choice' : 'assign', 'assign_target' : 'Captain'}, data.target_rank == 'Captain' ? 'disabled' : null)}}
@@ -158,14 +155,6 @@
                 </td>
               </tr>
               <tr>
-                <th style="color: '#800080';">Science</th>
-                <td>
-                  {{for data.science_jobs}}
-                    {{:helper.link(value.display_name, '', {'choice' : 'assign', 'assign_target' : value.job}, data.target_rank == value.job ? 'disabled' : null)}}
-                  {{/for}}
-                </td>
-              </tr>
-              <tr>
                 <th style="color: '#DD0000';">Security</th>
                 <td>
                   {{for data.security_jobs}}
@@ -174,6 +163,22 @@
                 </td>
               </tr>
               <tr>
+              <tr>
+                <th style="color: '#C060C0';">Science</th>
+                <td>
+                  {{for data.science_jobs}}
+                    {{:helper.link(value.display_name, '', {'choice' : 'assign', 'assign_target' : value.job}, data.target_rank == value.job ? 'disabled' : null)}}
+                  {{/for}}
+                </td>
+              </tr>
+              <tr>
+                <th style="color: '#A0A0A0';">Support</th>
+                <td>
+                  {{for data.support_jobs}}
+                    {{:helper.link(value.display_name, '', {'choice' : 'assign', 'assign_target' : value.job}, data.target_rank == value.job ? 'disabled' : null)}}
+                  {{/for}}
+                </td>
+              </tr>
                 <th style="color: '#808080';">Civilian</th>
                 <td>
                   {{for data.civilian_jobs}}


### PR DESCRIPTION
Finally puts support jobs back on the ID (HoP) computer.

Removed NT rep from the list of positions that can be chosen (as it's a
central assigned position only).

Slightly altered the colours of the interface to make it easier to read.
