### PR TITLE
Rolling Paper Icon Fix

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -474,7 +474,7 @@ obj/item/weapon/rollingpaper
 	name = "rolling paper"
 	desc = "A thin piece of paper used to make fine smokeables."
 	icon = 'icons/obj/cigarettes.dmi'
-	icon_state = "cig_paper"
+	icon_state = "cig paper"
 	w_class = 1
 
 


### PR DESCRIPTION
Fixes icon_state of individual sheets of rolling paper so they actually show the rolling paper sprite, rather than no sprite at all.
