### PR TITLE
Update nuclear bomb's regular and hacking UI to NanoUI

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -22,6 +22,7 @@ var/bomb_set
 	var/safety_wire
 	var/timing_wire
 	var/removal_stage = 0 // 0 is no removal, 1 is covers removed, 2 is covers open, 3 is sealant open, 4 is unwrenched, 5 is removed from bolts.
+	var/lastentered
 	var/data[0]	
 	var/uiwidth
 	var/uiheight
@@ -321,9 +322,15 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 						src.yes_code = 0
 						src.code = null
 					else
-						src.code += text("[]", href_list["type"])
-						if (length(src.code) > 5)
-							src.code = "ERROR"
+						lastentered = text("[]", href_list["type"])
+						if (text2num(lastentered) == null)
+							var/turf/LOC = get_turf(usr)
+							message_admins("[key_name_admin(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: <a href='?_src_=vars;Vars=\ref[src]'>[lastentered]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
+							log_admin("EXPLOIT : [key_name(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: [lastentered] !")
+						else
+							src.code += lastentered
+							if (length(src.code) > 5)
+								src.code = "ERROR"
 			if (src.yes_code)
 				if (href_list["time"])
 					var/time = text2num(href_list["time"])

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -194,17 +194,14 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 		if (src.auth)
 			if (src.yes_code)
 				data["authstatus"] = src.timing ? "Functional/Set" : "Functional"
-				data["safe"] = src.safety ? "Safe" : "Engaged"
 			else
 				data["authstatus"] = "Auth. S2"
-				data["safe"] = src.safety ? "Safe" : "Engaged"
 		else
 			if (src.timing)	
 				data["authstatus"] = "Set"
-				data["safe"] = src.safety ? "Safe" : "Engaged"
 			else
 				data["authstatus"] = "Auth. S1"
-				data["safe"] = src.safety ? "Safe" : "Engaged"			
+		data["safe"] = src.safety ? "Safe" : "Engaged"			
 		data["time"] = src.timeleft	
 		data["timer"] = src.timing
 		data["safety"] = src.safety

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -325,8 +325,8 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 						lastentered = text("[]", href_list["type"])
 						if (text2num(lastentered) == null)
 							var/turf/LOC = get_turf(usr)
-							message_admins("[key_name_admin(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: <a href='?_src_=vars;Vars=\ref[src]'>[lastentered]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
-							log_admin("EXPLOIT : [key_name(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: [lastentered] !")
+							message_admins("[key_name_admin(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: <a href='?_src_=vars;Vars=\ref[src]'>[lastentered]</a>! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
+							log_admin("EXPLOIT : [key_name(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: [lastentered]!")
 						else
 							src.code += lastentered
 							if (length(src.code) > 5)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -21,17 +21,17 @@ var/bomb_set
 	var/light_wire
 	var/safety_wire
 	var/timing_wire
-	var/removal_stage = 0 // 0 is no removal, 1 is covers removed, 2 is covers open,
-	                      // 3 is sealant open, 4 is unwrenched, 5 is removed from bolts.
+	var/removal_stage = 0 // 0 is no removal, 1 is covers removed, 2 is covers open, 3 is sealant open, 4 is unwrenched, 5 is removed from bolts.
+	var/data[0]	
+	var/uiwidth
+	var/uiheight
+	var/uititle
 	flags = FPRINT
 	use_power = 0
-
-
 
 /obj/machinery/nuclearbomb/New()
 	..()
 	r_code = "[rand(10000, 99999.0)]"//Creates a random code upon object spawn.
-
 	src.wires["Red"] = 0
 	src.wires["Blue"] = 0
 	src.wires["Green"] = 0
@@ -55,11 +55,10 @@ var/bomb_set
 			explode()
 		for(var/mob/M in viewers(1, src))
 			if ((M.client && M.machine == src))
-				src.attack_hand(M)
+				nanomanager.update_uis(src)
 	return
 
 /obj/machinery/nuclearbomb/attackby(obj/item/weapon/O as obj, mob/user as mob)
-
 	if (istype(O, /obj/item/weapon/screwdriver))
 		src.add_fingerprint(user)
 		if (src.auth)
@@ -67,35 +66,37 @@ var/bomb_set
 				src.opened = 1
 				overlays += image(icon, "npanel_open")
 				user << "You unscrew the control panel of [src]."
-
 			else
 				src.opened = 0
 				overlays -= image(icon, "npanel_open")
 				user << "You screw the control panel of [src] back on."
 		else
 			if (src.opened == 0)
-				user << "The [src] emits a buzzing noise, the panel staying locked in."
+				user << "[src] emits a buzzing noise, the panel staying locked in."
 			if (src.opened == 1)
 				src.opened = 0
 				overlays -= image(icon, "npanel_open")
 				user << "You screw the control panel of [src] back on."
 			flick("nuclearbombc", src)
-
+		ui_interact(user)
 		return
 
+	if (istype(O, /obj/item/device/multitool) || istype(O, /obj/item/weapon/wirecutters))
+		ui_interact(user)
+		
 	if (src.extended)
 		if (istype(O, /obj/item/weapon/disk/nuclear))
 			usr.drop_item()
 			O.loc = src
 			src.auth = O
 			src.add_fingerprint(user)
+			nanomanager.update_uis(src)
 			return
 
 	if (src.anchored)
 		switch(removal_stage)
 			if(0)
 				if(istype(O,/obj/item/weapon/weldingtool))
-
 					var/obj/item/weapon/weldingtool/WT = O
 					if(!WT.isOn()) return
 					if (WT.get_fuel() < 5) // uses up 5 fuel.
@@ -169,25 +170,7 @@ var/bomb_set
 		if (src.opened)
 			nukehack_win(user,50)
 		user.set_machine(src)
-		var/dat = text("<TT><B>Nuclear Fission Explosive</B><BR>\nAuth. Disk: <A href='?src=\ref[];auth=1'>[]</A><HR>", src, (src.auth ? "++++++++++" : "----------"))
-		if (src.auth)
-			if (src.yes_code)
-				dat += text("\n<B>Status</B>: []-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] <A href='?src=\ref[];timer=1'>Toggle</A><BR>\nTime: <A href='?src=\ref[];time=-10'>-</A> <A href='?src=\ref[];time=-1'>-</A> [] <A href='?src=\ref[];time=1'>+</A> <A href='?src=\ref[];time=10'>+</A><BR>\n<BR>\nSafety: [] <A href='?src=\ref[];safety=1'>Toggle</A><BR>\nAnchor: [] <A href='?src=\ref[];anchor=1'>Toggle</A><BR>\n", (src.timing ? "Func/Set" : "Functional"), (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src, src, src, src.timeleft, src, src, (src.safety ? "On" : "Off"), src, (src.anchored ? "Engaged" : "Off"), src)
-			else
-				dat += text("\n<B>Status</B>: Auth. S2-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\n[] Safety: Toggle<BR>\nAnchor: [] Toggle<BR>\n", (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src.timeleft, (src.safety ? "On" : "Off"), (src.anchored ? "Engaged" : "Off"))
-		else
-			if (src.timing)
-				dat += text("\n<B>Status</B>: Set-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\nSafety: [] Toggle<BR>\nAnchor: [] Toggle<BR>\n", (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src.timeleft, (src.safety ? "On" : "Off"), (src.anchored ? "Engaged" : "Off"))
-			else
-				dat += text("\n<B>Status</B>: Auth. S1-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\nSafety: [] Toggle<BR>\nAnchor: [] Toggle<BR>\n", (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src.timeleft, (src.safety ? "On" : "Off"), (src.anchored ? "Engaged" : "Off"))
-		var/message = "AUTH"
-		if (src.auth)
-			message = text("[]", src.code)
-			if (src.yes_code)
-				message = "*****"
-		dat += text("<HR>\n>[]<BR>\n<A href='?src=\ref[];type=1'>1</A>-<A href='?src=\ref[];type=2'>2</A>-<A href='?src=\ref[];type=3'>3</A><BR>\n<A href='?src=\ref[];type=4'>4</A>-<A href='?src=\ref[];type=5'>5</A>-<A href='?src=\ref[];type=6'>6</A><BR>\n<A href='?src=\ref[];type=7'>7</A>-<A href='?src=\ref[];type=8'>8</A>-<A href='?src=\ref[];type=9'>9</A><BR>\n<A href='?src=\ref[];type=R'>R</A>-<A href='?src=\ref[];type=0'>0</A>-<A href='?src=\ref[];type=E'>E</A><BR>\n</TT>", message, src, src, src, src, src, src, src, src, src, src, src, src)
-		user << browse(dat, "window=nuclearbomb;size=300x400")
-		onclose(user, "nuclearbomb")
+		ui_interact(user)
 	else if (src.deployable)
 		if(removal_stage < 5)
 			src.anchored = 1
@@ -201,15 +184,56 @@ var/bomb_set
 	return
 
 obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
-	var/dat as text
-	dat += "<TT><B>Nuclear Fission Explosive</B><BR>\nNuclear Device Wires:</A><HR>"
-	for(var/wire in src.wires)
-		dat += text("[wire] Wire: <A href='?src=\ref[src];wire=[wire];act=wire'>[src.wires[wire] ? "Mend" : "Cut"]</A> <A href='?src=\ref[src];wire=[wire];act=pulse'>Pulse</A><BR>")
-	dat += text("<HR>The device is [src.timing ? "shaking!" : "still"]<BR>")
-	dat += text("The device is [src.safety ? "quiet" : "whirring"].<BR>")
-	dat += text("The lights are [src.lighthack ? "static" : "functional"].<BR>")
-	user << browse("<HTML><HEAD><TITLE>Bomb Defusion</TITLE></HEAD><BODY>[dat]</BODY></HTML>","window=nukebomb_hack")
-	onclose(user, "nukebomb_hack")
+	ui_interact(user)
+	
+/obj/machinery/nuclearbomb/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+	if(!src.opened)
+		data["hacking"] = 0
+		data["auth"] = src.auth
+		if (src.auth)
+			if (src.yes_code)
+				data["authstatus"] = src.timing ? "Functional/Set" : "Functional"
+				data["safe"] = src.safety ? "Safe" : "Engaged"
+			else
+				data["authstatus"] = "Auth. S2"
+				data["safe"] = src.safety ? "Safe" : "Engaged"
+		else
+			if (src.timing)	
+				data["authstatus"] = "Set"
+				data["safe"] = src.safety ? "Safe" : "Engaged"
+			else
+				data["authstatus"] = "Auth. S1"
+				data["safe"] = src.safety ? "Safe" : "Engaged"			
+		data["time"] = src.timeleft	
+		data["timer"] = src.timing
+		data["safety"] = src.safety
+		data["anchored"] = src.anchored
+		data["yescode"] = src.yes_code
+		data["message"] = "AUTH"
+		if (src.auth)
+			data["message"] = src.code
+			if (src.yes_code)
+				data["message"] = "*****"
+		uiwidth = 300
+		uiheight = 510
+		uititle = "Nuke Control Panel"
+	else
+		data["hacking"] = 1
+		var/list/tempwires[0] 
+		for(var/wire in src.wires)
+			tempwires.Add(list(list("name" = wire, "cut" = src.wires[wire])))
+		data["wires"] = tempwires
+		data["timing"] = src.timing
+		data["safety"] = src.safety
+		data["lighthack"] = src.lighthack
+		uiwidth = 420
+		uiheight = 440
+		uititle = "Nuclear Bomb Defusion"
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)	
+	if (!ui)
+		ui = new(user, src, ui_key, "nuclear_bomb.tmpl", uititle, uiwidth, uiheight)
+		ui.set_initial_data(data)		
+		ui.open()
 
 /obj/machinery/nuclearbomb/verb/make_deployable()
 	set category = "Object"
@@ -224,9 +248,9 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 		src.deployable = 1
 	return
 
-
 /obj/machinery/nuclearbomb/Topic(href, href_list)
-	..()
+	if(..())
+		return
 	if (!usr.canmove || usr.stat || usr.restrained())
 		return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))))
@@ -309,7 +333,8 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 					if (src.timing == -1.0)
 						return
 					if (src.safety)
-						usr << "\red The safety is still on."
+						usr << "\red The safety is still on."	
+						nanomanager.update_uis(src)						
 						return
 					src.timing = !( src.timing )
 					if (src.timing)
@@ -329,7 +354,6 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 						src.timing = 0
 						bomb_set = 0
 				if (href_list["anchor"])
-
 					if(removal_stage == 5)
 						src.anchored = 0
 						visible_message("\red \The [src] makes a highly unpleasant crunching noise. It looks like the anchoring bolts have been cut.")
@@ -344,9 +368,8 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 		src.add_fingerprint(usr)
 		for(var/mob/M in viewers(1, src))
 			if ((M.client && M.machine == src))
-				src.attack_hand(M)
+				nanomanager.update_uis(src)
 	else
-		usr << browse(null, "window=nuclearbomb")
 		return
 	return
 
@@ -398,8 +421,12 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 			ticker.mode.explosion_in_progress = 0
 			if(ticker.mode.name == "nuclear emergency")
 				ticker.mode:nukes_left --
+			else if(off_station == 1)
+				world << "<b>A nuclear device was set off, but the explosion was out of reach of the station!</b>"				
+			else if(off_station == 2)
+				world << "<b>A nuclear device was set off, but the device was not on the station!</b>"
 			else
-				world << "<B>The station was destoyed by the nuclear blast!</B>"
+				world << "<b>The station was destoyed by the nuclear blast!</b>"
 
 			ticker.mode.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
 															//kinda shit but I couldn't  get permission to do what I wanted to do.
@@ -412,7 +439,7 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 				if(blackbox)
 					blackbox.save_all_data_to_sql()
 				sleep(300)
-				log_game("Rebooting due to nuclear detonation")
+				log_game("Rebooting due to nuclear detonation.")
 				world.Reboot()
 				return
 	return

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -329,6 +329,11 @@ proc/trigger_armed_response_team(var/force = 0)
 	if (leader_selected)
 		W.access += access_cent_teleporter
 	equip_to_slot_or_del(W, slot_wear_id)
+	
+	// Loyalty implant
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)
+	L.imp_in = src
+	L.implanted = 1
 
 	return 1
 

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -416,8 +416,7 @@ div.notice {
     float: right;
 }
 
-/* Used in PDA */
-
+/* PDA styling */
 .wholeScreen {
     position: absolute;
     color: #517087;
@@ -431,8 +430,7 @@ div.notice {
     white-space: nowrap;
 }
 
-/* DNA Modifier UI (dna_modifier.tmpl) */
-
+/* DNA Modifier styling */
 .dnaBlock {
     float: left;
     width: 90px;
@@ -475,7 +473,7 @@ div.notice {
     text-align: center;
 }
 
-/* Table stuffs for power monitor */
+/* Table styling for the power monitor */
 table.pmon {
     border: 2px solid RoyalBlue;
 }
@@ -485,8 +483,7 @@ table.pmon td, table.pmon th {
     padding: 0px 5px 0px 5px;
 }
 
-/* Table Stuffs for manifest*/
-
+/* Table styling for the crew manifest */
 th.command {
     background: #3333FF;
     font-weight: bold;
@@ -530,7 +527,6 @@ th.misc {
 }
 
 /* Damage colors for crew monitoring computer */
-
 .burn {
     color: orange;
 }
@@ -553,4 +549,33 @@ th.misc {
 
 .oxyloss_light {
     color: #6698FF;
+}
+
+/* Wire colors for nuclear bomb defusion */
+.Red {
+    color: #FF0000;
+}
+
+.Blue {
+    color: #0000FF;
+}
+
+.Green {
+    color: #00FF00;
+}
+
+.Marigold {
+    color: #FDA505;
+}
+
+.Fuschia {
+    color: #FF0080;
+}
+
+.Black {
+    color: #000000;
+}
+
+.Pearl {
+    color: #C6CACB;
 }

--- a/nano/templates/keycard_auth.tmpl
+++ b/nano/templates/keycard_auth.tmpl
@@ -1,7 +1,7 @@
 <!-- 
 Title: Keycard Authentication Device UI
 Used In File(s): \code\modules\security_levels\keycard_authentication.dm
- -->
+-->
 <div class="item">
 	<h1>Keycard Authentication Device</h1>
 	This device is used to trigger certain high security events. It requires the simultaneous swipe of two high-level ID cards.

--- a/nano/templates/nuclear_bomb.tmpl
+++ b/nano/templates/nuclear_bomb.tmpl
@@ -1,0 +1,85 @@
+<!-- 
+Title: Nuke Control Panel/Nuclear Bomb Defusion
+Used In File(s): \code\game\gamemodes\nuclear\nuclearbomb.dm
+-->
+{{if !data.hacking}}
+	<div class="item">
+		<b>Authorization Disk:</b> {{if data.auth}}{{:helper.link('++++++++++', 'eject', {'auth' : 1})}} {{else}} {{:helper.link('----------', 'disk', {'auth' : 1})}}{{/if}}
+	</div>	
+	<hr>
+	<div class="item">
+		<div><b>Status:</b> {{:data.authstatus}} - {{:data.safe}}</div>
+		<div><b>Timer:</b> {{:data.time}}</div>
+	</div>
+	<div class="item">
+		<div class="item">
+			{{if data.auth && data.yescode}}
+				<div class="item">
+					<b>Timer:</b> {{:helper.link('On', 'play', {'timer' : 1}, data.timer ? 'selected' : '')}}{{:helper.link('Off', 'stop', {'timer' : 0}, !data.timer ? 'selected' : '')}}
+				</div>
+				<div class="item">
+					<b>Time:</b> {{:helper.link('--', '', {'time' : -10}, data.time <= 60 ? 'disabled' : '')}}{{:helper.link('-', '', {'time' : -1}, data.time <= 60 ? 'disabled' : '')}} {{:data.time}} {{:helper.link('+', '', {'time' : 1})}}{{:helper.link('++', '', {'time' : 10})}}
+				</div>
+			{{else}}
+				<div class="item">
+					<b>Timer:</b> {{:helper.link('On', 'play', null, 'disabled')}}{{:helper.link('Off', 'pause', null, 'disabled')}}
+				</div>
+				<div class="item">
+					<b>Time:</b> {{:helper.link('-', '', null, 'disabled')}}{{:helper.link('-', '', null, 'disabled')}} {{:data.time}} {{:helper.link('+', '', null, 'disabled')}}{{:helper.link('++', '', null, 'disabled')}}
+				</div>
+			{{/if}}
+		</div>
+		<div class="item">
+			{{if data.auth && data.yescode}}
+				<div class="item">
+					<b>Safety:</b> {{:helper.link('Engaged', 'info', {'safety' : 1}, data.safety ? 'selected' : '')}}{{:helper.link('Disengaged', 'alert', {'safety' : 0}, data.safety ? '' : 'selected')}}
+				</div>
+				<div class="item">
+					<b>Anchor:</b> {{:helper.link('Engaged', 'locked', {'anchor' : 1}, data.anchored ? 'selected' : '')}}{{:helper.link('Disengaged', 'unlocked', {'anchor' : 0}, data.anchored ? '' : 'selected')}}
+				</div>
+			{{else}}
+				<div class="item">
+					<b>Safety:</b> {{:helper.link('Engaged', 'info', null, 'disabled')}}{{:helper.link('Disengaged', 'alert', null, 'disabled')}}
+				</div>
+				<div class="item">
+					<b>Anchor:</b> {{:helper.link('Engaged', 'locked', null, 'disabled')}}{{:helper.link('Disengaged', 'unlocked', null, 'disabled')}}
+				</div>	
+			{{/if}}
+		</div>
+		<hr>
+	</div>
+	<div class="item">
+		<div class="item">
+			>{{if data.message}} {{:data.message}}{{/if}}
+		</div>
+		<div class="item">
+			<div class="item">
+				{{:helper.link('1', '', {'type' : 1})}}{{:helper.link('2', '', {'type' : 2})}}{{:helper.link('3', '', {'type' : 3})}}
+			</div>
+			<div class="item">
+				{{:helper.link('4', '', {'type' : 4})}}{{:helper.link('5', '', {'type' : 5})}}{{:helper.link('6', '', {'type' : 6})}}
+			</div>
+			<div class="item">
+				{{:helper.link('7', '', {'type' : 7})}}{{:helper.link('8', '', {'type' : 8})}}{{:helper.link('9', '', {'type' : 9})}}
+			</div>
+			<div class="item">
+				{{:helper.link('R', '', {'type' : 'R'})}}{{:helper.link('0', '', {'type' : 0})}}{{:helper.link('E', '', {'type' : 'E'})}}
+			</div>
+		</div>
+	</div>
+{{else}}
+	<div class="block">
+		<h3>Exposed Wires</h3>
+		{{for data.wires}}
+			<div class="item">
+				<div class="{{:value.name}} itemLabel">{{:value.name}}</div>
+				<div class="itemContent">{{:helper.link(value.cut ? 'Mend' : 'Cut', '', {'wire' : value.name, 'act' : 'wire'})}} {{:helper.link('Pulse', '', {'wire' : value.name, 'act' : 'pulse'})}}</div>
+			</div>
+		{{/for}}
+	</div>
+	<div class="item">
+		The device is {{if data.timing}}shaking!{{else}}still.{{/if}}<br />
+		The device is {{if data.safety}}quiet.{{else}}whirring.{{/if}}<br />
+		The lights are {{if data.lighthack}}static.{{else}}functional.{{/if}}<br />
+	</div>
+{{/if}}

--- a/nano/templates/telescience_console.tmpl
+++ b/nano/templates/telescience_console.tmpl
@@ -1,7 +1,7 @@
 <!-- 
 Title: Telescience Control UI 
 Used In File(s): \code\game\machinery\computer\telescience.dm
- -->
+-->
 <div class="item">
 	<div class="itemLabel">Coordinates:</div>
 	<div class="itemContent">


### PR DESCRIPTION
Changes:
1. Changes the nuclear bomb's regular and hacking UI to NanoUI.
2. The end of round message now distinguishes between the bomb being on station, off station (as in, far from the station but on z-level 1) and on another z-level. While the code previously did take this into account, the message would always be the same.
3. Fixed an HTML injection exploit in the nuclear device code (ported from /tg/).
4. The Emergency Response Team now spawns loyalty implanted.
