### PR TITLE
Botany Mutation Rework

### DIFF
--- a/code/game/machinery/hydroponics.dm
+++ b/code/game/machinery/hydroponics.dm
@@ -111,12 +111,15 @@
 		"left4zed" =       list(  0,    0,   0.2 )
 		)
 
-	// Mutagen list specifies minimum value for the mutation to take place, rather
-	// than a bound as the lists above specify.
+	//--FalseIncarnate
+	// Mutagen list specifies reagent_min_value and reagent_step
+	// Reagent_min_value (value 1) is the minimum number of units needed to begin mutations
+	// Reagent_step (value 2) is the number of units between each mutation threshold
 	var/global/list/mutagenic_reagents = list(
-		"radium" =  list(8,3),
-		"mutagen" = list(3,8)
+		"radium" =  list(10,10),
+		"mutagen" = list(1,5)
 		)
+	//--FalseIncarnate
 
 /obj/machinery/portable_atmospherics/hydroponics/New()
 	..()
@@ -336,13 +339,25 @@
 				mutation_mod += beneficial_reagents[R.id][3] * reagent_total
 
 			// Mutagen is distinct from the previous types and mostly has a chance of proccing a mutation.
-			if(mutagenic_reagents[R.id])
-				var/reagent_min_value = mutagenic_reagents[R.id][1]
-				var/reagent_value =     mutagenic_reagents[R.id][2]+mutation_mod
 
-				if(reagent_total >= reagent_min_value)
-					if(prob(min(reagent_total*reagent_value,100)))
-						mutate(reagent_total > 10 ? 2 : 1)
+			//--FalseIncarnate
+			// Mutation rework, will now use "thresholds" for proccing types of mutations and their respective chances.
+			// This should make it easier to avoid species shifts when trying to only affect stats like potency.
+			// Additionally, the chance of mutations will vary depending on the amount of mutagenic reagents added.
+			if(mutagenic_reagents[R.id])
+				var/reagent_min_value = mutagenic_reagents[R.id][1]					//10 for radium, 1 for unstable mutagen
+				var/reagent_step =     mutagenic_reagents[R.id][2]					//10 for radium, 5 for unstable mutagen
+
+				if(reagent_total >= reagent_min_value + (3 * reagent_step))			//31+ for radium, 16+ for unstable mutagen
+					mutate(4)
+				else if(reagent_total >= reagent_min_value + (2 * reagent_step))	//21-30 for radium, 11-15 for unstable mutagen
+					mutate(3)
+				else if(reagent_total >= reagent_min_value + reagent_step)			//11-20 for radium, 6-10 for unstable mutagen
+					mutate(2)
+				else if(reagent_total >= reagent_min_value)							//1-10 for radium, 1-5 for unstable mutagen
+					mutate(1)
+
+			//--FalseIncarnate
 
 		// Handle nutrient refilling.
 		if(nutrient_reagents[R.id])
@@ -484,26 +499,6 @@
 
 	return
 
-/obj/machinery/portable_atmospherics/hydroponics/proc/mutate(var/severity)
-
-	// No seed, no mutations.
-	if(!seed)
-		return
-
-	// Check if we should even bother working on the current seed datum.
-	if(seed.mutants. && seed.mutants.len && severity > 1 && prob(10+mutation_mod))
-		mutate_species()
-		return
-
-	// We need to make sure we're not modifying one of the global seed datums.
-	// If it's not in the global list, then no products of the line have been
-	// harvested yet and it's safe to assume it's restricted to this tray.
-	if(!isnull(seed_types[seed.name]))
-		seed = seed.diverge()
-	seed.mutate(severity,get_turf(src))
-
-	return
-
 /obj/machinery/portable_atmospherics/hydroponics/proc/check_level_sanity()
 	//Make sure various values are sane.
 	if(seed)
@@ -518,6 +513,85 @@
 	weedlevel =  max(0,min(weedlevel,10))
 	toxins =     max(0,min(toxins,10))
 
+/obj/machinery/portable_atmospherics/hydroponics/proc/mutate(var/severity)
+
+	// No seed, no mutations.
+	if(!seed)
+		return
+
+	/*
+	--FalseIncarnate
+	New mutation system, now uses "Mutation Tiers" to adjust the chances of mutations
+		Tier 1 has a low chance of causing a stat mutation
+		Tier 2 has a higher chance of causing a stat mutation
+		Tier 3 has a low chance of causing a species shift (if possible), and will ALWAYS cause a stat mutation if it does not shift species
+		Tier 4 has a higher chance of causing a species shift (if possible), and will ALWAYS cause a stat mutation if it does not shift species
+			Tier 4 also has a low chance to cause a SECOND stat mutation when it does not shift species
+	All mutation chances are increased by the mutation_mod value. Mutation_mod is not transferred into seeds/harvests, and is reset when the plant dies
+
+	*/
+
+	switch(severity)
+		if(1)
+			if(prob(20+mutation_mod))							//Low chance of stat mutation
+				if(!isnull(seed_types[seed.name]))
+					seed = seed.diverge()
+				seed.mutate(severity,get_turf(src))
+				return
+		if(2)
+			if(prob(60+mutation_mod))							//Higher chance of stat mutation
+				if(!isnull(seed_types[seed.name]))
+					seed = seed.diverge()
+				seed.mutate(severity,get_turf(src))
+				return
+		if(3)
+			if(prob(20+mutation_mod))							//Low chance of species shift mutation
+				if(seed.mutants. && seed.mutants.len)			//Check if current seed/plant has mutant species
+					mutate_species()
+				else											//No mutant species, mutate stats instead
+					if(!isnull(seed_types[seed.name]))
+						seed = seed.diverge()
+					seed.mutate(severity,get_turf(src))
+				return
+			else												//Failed to shift, mutate stats instead
+				if(!isnull(seed_types[seed.name]))
+					seed = seed.diverge()
+				seed.mutate(severity,get_turf(src))
+				return
+		if(4)
+			if(prob(60+mutation_mod))							//Higher chance of species shift mutation
+				if(seed.mutants. && seed.mutants.len)			//Check if current seed/plant has mutant species
+					mutate_species()
+				else											//No mutant species, mutate stats instead
+					if(!isnull(seed_types[seed.name]))
+						seed = seed.diverge()
+					seed.mutate(severity,get_turf(src))
+					if(prob(20+mutation_mod))					//Chance for second stat mutation
+						if(!isnull(seed_types[seed.name]))
+							seed = seed.diverge()
+						seed.mutate(severity,get_turf(src))
+				return
+			else												//Failed to shift, mutate stats instead
+				if(!isnull(seed_types[seed.name]))
+					seed = seed.diverge()
+				seed.mutate(severity,get_turf(src))
+				if(prob(20+mutation_mod))						//Chance for second stat mutation
+					if(!isnull(seed_types[seed.name]))
+						seed = seed.diverge()
+					seed.mutate(severity,get_turf(src))
+				return
+
+	/* code references
+	// We need to make sure we're not modifying one of the global seed datums.
+	// If it's not in the global list, then no products of the line have been
+	// harvested yet and it's safe to assume it's restricted to this tray.
+	if(!isnull(seed_types[seed.name]))
+		seed = seed.diverge()
+	seed.mutate(severity,get_turf(src))
+	*/
+
+	//--FalseIncarnate
+
 /obj/machinery/portable_atmospherics/hydroponics/proc/mutate_species()
 
 	var/previous_plant = seed.display_name
@@ -528,7 +602,7 @@
 		return
 
 	dead = 0
-	mutate(1)
+	//mutate(1)
 	age = 0
 	health = seed.endurance
 	lastcycle = world.time

--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -47,11 +47,12 @@ Growing it to term with nothing injected will grab a ghost from the observers. *
 				for(var/mob/O in respawnable_list)
 					if(O.mind == source.mind && config.revival_pod_plants)
 						message_admins("Found mind, asking for respawn")
-						switch(alert(O,"Your corpse has been placed into a pod plant. Do you want to be resurrected/cloned? Please not if you select 'No', you will be able to be cloned or borged again this round.","Pod Alert","Yes","No"))
+						switch(alert(O,"Your corpse has been placed into a pod plant. Do you want to be resurrected/cloned? Please note if you select 'No', you will still be able to be cloned or borged again this round.","Pod Alert","Yes","No"))
 							if("Yes")
 								source.key = O.key
 								return
 							if("No")
+								user << "The seeds seem to reject the blood, returning to their original size as they stop quivering."
 								return
 		else
 			user << "Nothing happens."

--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -18,6 +18,17 @@
 
 	var/datum/seed/grown_seed
 	var/datum/reagents/grown_reagents
+
+	//--FalseIncarnate
+	var/IS_TRAY = 0			//used to track if the target is a hydroponics tray or soil. 1 if true, otherwise 0
+	var/tray_age			//age of the plant in the tray
+	var/tray_weed_level		//weed level of tray
+	var/tray_pest_level		//pest level of tray
+	var/tray_toxins			//toxicity of the tray
+	var/tray_yield_mod		//yield modifier of the tray
+	var/tray_mutation_mod	//mutation modifier of the tray
+	//--FalseIncarnate
+
 	if(istype(target,/obj/item/weapon/reagent_containers/food/snacks/grown))
 
 		var/obj/item/weapon/reagent_containers/food/snacks/grown/G = target
@@ -38,6 +49,19 @@
 	else if(istype(target,/obj/machinery/portable_atmospherics/hydroponics))
 
 		var/obj/machinery/portable_atmospherics/hydroponics/H = target
+
+		//--FalseIncarnate
+		//Flag the target as a tray for showing tray-specific stats
+		IS_TRAY = 1
+		//Save tray data to matching variables
+		tray_age			= H.age
+		tray_weed_level		= H.weedlevel
+		tray_pest_level		= H.pestlevel
+		tray_toxins			= H.toxins
+		tray_yield_mod		= H.yield_mod
+		tray_mutation_mod	= H.mutation_mod
+		//--FalseIncarnate
+
 		grown_seed = H.seed
 		grown_reagents = H.reagents
 
@@ -57,6 +81,19 @@
 	dat += "<tr><td><b>Maturation time</b></td><td>[grown_seed.maturation]</td></tr>"
 	dat += "<tr><td><b>Production time</b></td><td>[grown_seed.production]</td></tr>"
 	dat += "<tr><td><b>Potency</b></td><td>[grown_seed.potency]</td></tr>"
+
+	//--FalseIncarnate
+	//Tray-specific stats like Age and Mutation Modifier, not shown if target was not a hydroponics tray or soil
+	if(IS_TRAY == 1)
+		dat += "<tr><td></td></tr>"
+		dat += "<tr><td><b>Age</b></td><td>[tray_age]</td></tr>"
+		dat += "<tr><td><b>Weed Level</b></td><td>[tray_weed_level]</td></tr>"
+		dat += "<tr><td><b>Pest Level</b></td><td>[tray_pest_level]</td></tr>"
+		dat += "<tr><td><b>Toxins</b></td><td>[tray_toxins]</td></tr>"
+		dat += "<tr><td><b>Yield Modifier</b></td><td>[tray_yield_mod]</td></tr>"
+		dat += "<tr><td><b>Mutation Modifier</b></td><td>[tray_mutation_mod]</td></tr>"
+	//--FalseIncarnate
+
 	dat += "</table>"
 
 	if(grown_reagents && grown_reagents.reagent_list && grown_reagents.reagent_list.len)


### PR DESCRIPTION
Reworked the mutation system for Botany to use a "tier system",
adjusting mutation chances and the potential type of mutation based on
the amount of the reagent(s) added.

Also added additional information to the Plant Analyzer when scanning
trays. Will now include information such as age, yield modifier, and
toxicity in the report. This will not be shown when scanning harvested
goods or seeds.

Fixed some typos and missing words in podmen.dm in preparation of
planned attempt to reintegrate pod-cloning functionality.

Unreported change from my previous commit (this is for the sake of
documentation): End of round score will factor Hydroponics harvests into
the calculations.
