### PR TITLE
Makes NT Representative/Recruiter Karma locked again, SyndiBorg modtype fix

### DIFF
--- a/code/WorkInProgress/ZomgPonies/karma.dm
+++ b/code/WorkInProgress/ZomgPonies/karma.dm
@@ -155,8 +155,8 @@ You've gained <b>[totalkarma]</b> total karma in your time here.<br>"}
 			dat += {"
 			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=1'>Unlock Barber -- 5KP</a><br>
 			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=2'>Unlock Brig Physician -- 5KP</a><br>
-			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=8'>Unlock Nanotrasen Recruiter -- 10KP</a><br>
-			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=3'>Unlock Nanotrasen Representative -- 30KP</a><br>
+			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=8'>Unlock NanoTrasen Recruiter -- 10KP</a><br>
+			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=3'>Unlock NanoTrasen Representative -- 30KP</a><br>
 			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=4'>Unlock Customs Officer -- 30P</a><br>
 			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=5'>Unlock Blueshield -- 30KP</a><br>
 			<a href='?src=\ref[src];karmashop=shop;KarmaBuy=9'>Unlock Security Pod Pilot -- 30KP</a><br>

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -145,13 +145,13 @@ var/list/nonhuman_positions = list(
 var/list/whitelisted_positions = list(
 	"Blueshield",
 	"Customs Officer",
-	"Nanotrasen Representative",
+	"NanoTrasen Representative",
 	"Barber",
 	"Mechanic",
 	"Brig Physician",
 	"Magistrate",
 	"Security Pod Pilot",
-	"Nanotrasen Recruiter"
+	"NanoTrasen Recruiter"
 )
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1412,6 +1412,7 @@
 	modtype = "Synd"
 	faction = list("syndicate")
 	designation = "Syndicate"
+	modtype = "Syndicate"
 	req_access = list(access_syndicate)
 	
 /mob/living/silicon/robot/syndicate/New(loc)


### PR DESCRIPTION
Changes:
1) Fixes a bug where the NT Representative/Recruiter roles could be accessed by anyone.
2) The SyndiBorg is now labelled as a "Syndicate Cyborg".
